### PR TITLE
Add a edit on github link to the footer of the documentation

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %}
 {% block footer %}{% if sourcename %}
-    <div class="footer"><a href="https://github.com/codership/galera/blob/master/docs/source/{{ sourcename[0:-4] }}.rst">Edit on Github</a></div>
+    <div class="footer"><a href="https://github.com/codership/galera/blob/3.x/docs/source/{{ sourcename[0:-4] }}.rst">Edit on Github</a></div>
     {% endif %}{{ super() }}
 {% endblock %}


### PR DESCRIPTION
As suggested on the codership-team mailing list a link so anyone can edit the page on github would be a valuable way that documentation can be edited by the community and pass through a review process before its published on http://galeracluster.com/
