### PR TITLE
at some point the maximum wsrep_max_ws_size size became 4G

### DIFF
--- a/docs/source/mysqlwsrepoptions.rst
+++ b/docs/source/mysqlwsrepoptions.rst
@@ -262,7 +262,9 @@ The maximum number of rows allowed in the writeset. Currently, this parameter li
 .. index::
    pair: Parameters; wsrep_max_ws_size
 
-The maximum allowed writeset size. Currently, this parameter limits the supported size of transactions and ``LOAD DATA`` statements.
+The maximum allowed writeset size. This was the limit for the supported size of transactions and ``LOAD DATA`` statements however
+the real limition is in the wsrep provider. See ``repl.max_ws_size`` in :ref:`Galera Parameters <Galera Parameters>` for details and
+change its value to limit the transaction size. This parameter will be deprecated in the future.
 
 The maximum allowed writeset size is ``4G``.
 


### PR DESCRIPTION
<pre>
MariaDB [(none)]> set global wsrep_max_ws_size=2147483647*9;
Query OK, 0 rows affected, 1 warning (0.00 sec)

MariaDB [(none)]> select @@wsrep_max_ws_size;
+---------------------+
| @@wsrep_max_ws_size |
+---------------------+
|          4294901759 |
+---------------------+
</pre>


It does look whoever that repl.max_ws_size is limited to 2G.  Should this be increased?

<pre>
MariaDB [(none)]> set global wsrep_provider_options='repl.max_ws_size=2147483647';
Query OK, 0 rows affected (0.00 sec)

MariaDB [(none)]> set global wsrep_provider_options='repl.max_ws_size=2147483648';
ERROR 1210 (HY000): Incorrect arguments to SET
</pre>


| @@version                         |
| 5.5.37-MariaDB-1~wheezy-wsrep-log |
