### PR TITLE
Usage of invalidated iterator

### DIFF
--- a/gcomm/src/protostack.cpp
+++ b/gcomm/src/protostack.cpp
@@ -11,9 +11,9 @@ void gcomm::Protostack::push_proto(Protolay* p)
     Critical<Protostack> crit(*this);
     protos_.push_front(p);
 	
-	// connect the pushed Protolay that's now on top
-	// with the one that was previously on top,
-	// if we had one, of course.
+    // connect the pushed Protolay that's now on top
+    // with the one that was previously on top,
+    // if we had one, of course.
     if (protos_.size() > 1)
     {
         gcomm::connect(protos_[1], p);


### PR DESCRIPTION
After calling push_front() on a std::deque<>, iterators become invalid per the C++ standard ("after push_back() and push_front() all references stays valid, but iterators don't"). 

Using prev_begin after the push_front() call results in undefined behavior. This fix removes the usage of an invalid iterator and makes the intent of the code more clear.
