### PR TITLE
innodb_flush_log_at_trx_commit=0 based on oq blog

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -142,7 +142,7 @@ See below for an example *my.cnf* file::
     innodb_buffer_pool_size=28G
     innodb_log_file_size=100M
     innodb_file_per_table
-    innodb_flush_log_at_trx_commit=2
+    innodb_flush_log_at_trx_commit=0
 
     # 3. wsrep provider configuration: basic wsrep options
     wsrep_provider=/usr/lib64/galera/libgalera_smm.so

--- a/docs/source/dbconfiguration.rst
+++ b/docs/source/dbconfiguration.rst
@@ -22,7 +22,7 @@ In your configuration file, (my.cnf or my.ini, depending on your system), there 
 	innodb_buffer_pool_size=28G
 	innodb_log_file_size=100M
 	innodb_file_per_table=1
-	innodb_flush_log_at_trx_commit=2
+	innodb_flush_log_at_trx_commit=0
 	
 	# Basic wsrep Provider Settings
 	wsrep_provider=/usr/lib/galera/libgalera_smm.so


### PR DESCRIPTION
http://openquery.com.au/blog/innodbflushlogsontrxcommit-galeracluster
