### PR TITLE
refs #94 - bypass send monitor when sending state transfer request

### DIFF
--- a/galera/src/galera_gcs.hpp
+++ b/galera/src/galera_gcs.hpp
@@ -132,12 +132,12 @@ namespace galera
         ssize_t replv(const WriteSetVector& actv,
                       struct gcs_action& act, bool scheduled)
         {
-            return gcs_replv(conn_, &actv[0], &act, scheduled);
+            return gcs_replv(conn_, &actv[0], &act, scheduled, false);
         }
 
         ssize_t repl(struct gcs_action& act, bool scheduled)
         {
-            return gcs_repl(conn_, &act, scheduled);
+            return gcs_repl(conn_, &act, scheduled, false);
         }
 
         gcs_seqno_t caused() { return gcs_caused(conn_);   }

--- a/gcs/src/gcs.hpp
+++ b/gcs/src/gcs.hpp
@@ -210,21 +210,24 @@ struct gcs_action {
  * @param act_in    action buffer vector (total size is passed in action)
  * @param action    action struct
  * @param scheduled whether the call was preceded by gcs_schedule()
+ * @param bypass_sm bypass send monitor
  * @return          negative error code, action size in case of success
  * @retval -EINTR:  thread was interrupted while waiting to enter the monitor
  */
 extern long gcs_replv (gcs_conn_t*          conn,
                        const struct gu_buf* act_in,
                        struct gcs_action*   action,
-                       bool                 scheduled);
+                       bool                 scheduled,
+                       bool                 bypass_sm);
 
 /*! A wrapper for single buffer communication */
 static inline long gcs_repl (gcs_conn_t*        const conn,
                              struct gcs_action* const action,
-                             bool               const scheduled)
+                             bool               const scheduled,
+                             bool               const bypass_sm)
 {
     struct gu_buf const buf = { action->buf, action->size };
-    return gcs_replv (conn, &buf, action, scheduled);
+    return gcs_replv (conn, &buf, action, scheduled, bypass_sm);
 }
 
 /*! @brief Receives an action from group.

--- a/gcs/src/gcs_test.cpp
+++ b/gcs/src/gcs_test.cpp
@@ -381,7 +381,7 @@ void *gcs_test_repl (void *arg)
         if (ret < 0) break;
 
         /* replicate message */
-        ret = gcs_repl (gcs, &thread->act, false);
+        ret = gcs_repl (gcs, &thread->act, false, false);
 
         if (ret < 0) {
             assert (thread->act.seqno_g == GCS_SEQNO_ILL);


### PR DESCRIPTION
Allow bypassing send monitor when sending state transfer request. This is needed to avoid deadlock if send monitor becomes paused before sending STR.
