### PR TITLE
Manually cherry-pick old commits from unmerged Decembed 2014 branch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,13 +25,10 @@ Conflicts: garbd-2,
            percona-xtradb-cluster-galera-2.x,
            percona-xtradb-cluster-galera-3.x,
            percona-xtradb-cluster-garbd-2.x,
-           percona-xtradb-cluster-garbd-3.x,
-           galera
-Provides: galera-3,
-          wsrep,
-          galera,
-          galera3,
-          percona-xtradb-cluster-galera-25
+           percona-xtradb-cluster-garbd-3.x
+Breaks: galera
+Replaces: galera
+Provides: galera-3, wsrep
 Description: Replication framework for transactional applications
  Galera is a fast synchronous multimaster wsrep provider (replication engine)
  for transactional databases and similar applications. For more information

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,9 @@
 #!/usr/bin/make -f
 
 export DH_VERBOSE=1
+export DEB_BUILD_HARDENING=1
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
 
 # Parallel build support as adviced
 # at https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options


### PR DESCRIPTION
Commits:

* 44422ea09691d77e39ada4400077cd62ce4e8575
  Added Debian build hardening flags

* 05a3d0abe4fbedcac1ef621cd08b0fa54dffd81b
  d/control breaks/replaces package galera (from mariadb.org)

Also reverted the debian/* part of master 3.x branch the commit fa8d959
because the package should not fake that it provides galera versions
which it isn't fully compatible with.