### PR TITLE
Fix for ENOSYS error on posix_fallocate

### DIFF
--- a/galerautils/src/gu_fdesc.cpp
+++ b/galerautils/src/gu_fdesc.cpp
@@ -190,7 +190,7 @@ namespace gu
         if (0 != posix_fallocate (fd_, start, diff))
 #endif
         {
-            if (EINVAL == errno && start >= 0 && diff > 0)
+            if ((EINVAL == errno || ENOSYS == errno) && start >= 0 && diff > 0)
             {
                 // FS does not support the operation, try physical write
                 write_file (start);


### PR DESCRIPTION
When attempting to posix_fallocate on an OS where this system call isn't implemented, the entire startup process of MySQL fails with "File preallocation failed" instead of falling back to the write_file alternative. This fixes that issue.