### PR TITLE
Fixes codership/galera#186 - all sorts of problems with garbd system scr...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
   apt:
 #    sources:
 #      - ubuntu-toolchain-r-test
+#     https://github.com/travis-ci/travis-ci/issues/3668
+#     for alternatives in container builds
     packages:
       - libboost-program-options-dev
       - libssl-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@ language: cpp
 
 sudo: false
 
+cache:
+  - apt
+  - ccache
 compiler:
   - gcc
   - clang
 addons:
   apt:
-#    sources:
-#      - ubuntu-toolchain-r-test
+    sources:
+      - ubuntu-toolchain-r-test
 #     https://github.com/travis-ci/travis-ci/issues/3668
 #     for alternatives in container builds
     packages:
@@ -16,5 +19,15 @@ addons:
       - libssl-dev
       - check
       - scons
+      - gcc-4.9
+      - g++-4.9
 
-script: MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / }); MAX_JOBS=$(( ${RAM[1]} / 262144 )); echo Jobs\:\ $MAX_JOBS; ./scripts/build.sh -j $MAX_JOBS
+before_install:
+  - if [ ${CC} == "gcc" ]; then
+      export CC=`which gcc-4.9`;
+      export CXX=`which g++-4.9`;
+    fi
+
+script:
+  - ${CC} --version ; ${CXX} --version
+  - MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / }); MAX_JOBS=$(( ${RAM[1]} / 262144 )); echo Jobs\:\ $MAX_JOBS; ./scripts/build.sh -j $MAX_JOBS

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ addons:
       - libssl-dev
       - check
       - scons
-      - gcc-4.9
-      - g++-4.9
+      - gcc-5
+      - g++-5
 
 before_install:
   - if [ ${CC} == "gcc" ]; then
-      export CC=`which gcc-4.9`;
-      export CXX=`which g++-4.9`;
+      export CC=`which gcc-5`;
+      export CXX=`which g++-5`;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: cpp
 
+sudo: false
+
 compiler:
   - gcc
   - clang
+addons:
+  apt:
+#    sources:
+#      - ubuntu-toolchain-r-test
+    packages:
+      - libboost-program-options-dev
+      - libssl-dev
+      - check
+      - scons
 
-before_install:
-  # - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq || echo > /dev/null
-
-install:
-  - sudo apt-get install -y gcc g++ clang libboost-program-options-dev libssl-dev check scons
-  # - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
-  # - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
-
-script: MEM=$(head -1 /proc/meminfo); RAM=(${MEM// / }); MAX_JOBS=$(( ${RAM[1]} / 262144 )); echo Jobs\:\ $MAX_JOBS; ./scripts/build.sh -j $MAX_JOBS
+script: MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / }); MAX_JOBS=$(( ${RAM[1]} / 262144 )); echo Jobs\:\ $MAX_JOBS; ./scripts/build.sh -j $MAX_JOBS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-sudo: false
+sudo: true
 
 cache:
   - apt
@@ -27,9 +27,9 @@ addons:
 script:
   - if [ ${CC} != "clang" ]; then
       MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / });
-      MAX_JOBS=$(( ${RAM[1]} / 393216 )); echo Jobs\:\ $MAX_JOBS;
+      MAX_JOBS=$(( ${RAM[1]} / 393216 )); echo Max jobs\:\ $MAX_JOBS;
       CORES=$(grep -c ^processor /proc/cpuinfo);
-      [ $CORES -lt $MAX_JOBS ] && MAX_JOBS=$CORES;
+      [ $CORES -lt $MAX_JOBS ] && MAX_JOBS=$CORES; echo Real jobs\:\ $MAX_JOBS;
       ${CC} --version; ${CXX} --version;
       ./scripts/build.sh -j $MAX_JOBS;
       export CC=`which gcc-5`;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 
-sudo: true
+sudo: false
 
 cache:
   - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ sudo: false
 cache:
   - apt
   - ccache
+
 compiler:
   - gcc
   - clang
+
 addons:
   apt:
     sources:
@@ -22,12 +24,19 @@ addons:
       - gcc-5
       - g++-5
 
-before_install:
-  - if [ ${CC} == "gcc" ]; then
+script:
+  - if [ ${CC} != "clang" ]; then
+      MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / });
+      MAX_JOBS=$(( ${RAM[1]} / 393216 )); echo Jobs\:\ $MAX_JOBS;
+      CORES=$(grep -c ^processor /proc/cpuinfo);
+      [ $CORES -lt $MAX_JOBS ] && MAX_JOBS=$CORES;
+      ${CC} --version; ${CXX} --version;
+      ./scripts/build.sh -j $MAX_JOBS;
       export CC=`which gcc-5`;
       export CXX=`which g++-5`;
+      ${CC} --version; ${CXX} --version;
+      ./scripts/build.sh -j $MAX_JOBS;
+    else
+      ${CC} --version ; ${CXX} --version;
+      ./scripts/build.sh;
     fi
-
-script:
-  - ${CC} --version ; ${CXX} --version
-  - MEM=$(head -n 1 /proc/meminfo); RAM=(${MEM// / }); MAX_JOBS=$(( ${RAM[1]} / 262144 )); echo Jobs\:\ $MAX_JOBS; ./scripts/build.sh -j $MAX_JOBS

--- a/SConstruct
+++ b/SConstruct
@@ -20,7 +20,7 @@ import string
 
 sysname = os.uname()[0].lower()
 machine = platform.machine()
-bits = platform.architecture()[0]
+bits = ARGUMENTS.get('bits', platform.architecture()[0])
 print 'Host: ' + sysname + ' ' + machine + ' ' + bits
 
 x86 = 0
@@ -45,6 +45,7 @@ Commandline Options:
     revno=XXXX          source code revision number
     bpostatic=path      a path to static libboost_program_options.a
     extra_sysroot=path  a path to extra development environment (Fink, Homebrew, MacPorts, MinGW)
+    bits=[32bit|64bit]
 ''')
 # bpostatic option added on Percona request
 
@@ -303,7 +304,7 @@ if boost == 1:
     # Use nanosecond time precision
     conf.env.Append(CPPFLAGS = ' -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG=1')
     # Common procedure to find boost static library
-    boost_libpaths = [ boost_library_path, '/usr/local/lib', '/usr/local/lib64', '/usr/lib', '/usr/lib64' ]
+    boost_libpaths = [ boost_library_path, '/usr/lib64', '/usr/local/lib64'] if x86 == 64 else [ boost_library_path, '/usr/local/lib', '/usr/lib' ]
     def check_boost_library(libBaseName, header, configuredLibPath, autoadd = 1):
         libName = libBaseName + boost_library_suffix
         if configuredLibPath != '' and not os.path.isfile(configuredLibPath):

--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,7 @@ Architecture: any
 Conflicts: garbd-2, garbd2, percona-xtradb-cluster-garbd-2.x
 Breaks: percona-xtradb-cluster-galera-2.x
 Replaces: percona-xtradb-cluster-galera-2.x
-Depends: netcat-openbsd, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Galera arbitrator daemon
  Galera is a fast synchronous multimaster wsrep provider (replication engine)
  for transactional databases and similar applications. For more information

--- a/debian/rules
+++ b/debian/rules
@@ -30,7 +30,7 @@ override_dh_auto_build:
 
 # Start earlier than MySQL which has value 19
 override_dh_installinit-arch:
-	dh_installinit --name=garb -- defaults 18 22
+	dh_installinit -n --name=garb -- defaults 18 22
 
 override_dh_strip:
 	dh_strip -pgalera-3 --dbg-package=galera-3-dbg

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -59,14 +59,14 @@ apply_trx_ws(void*                    recv_ctx,
                 if (err > 0)
                 {
                     wsrep_bool_t unused(false);
-                    int const rcode(
+                    wsrep_cb_status const rcode(
                         commit_cb(
                             recv_ctx,
                             TrxHandle::trx_flags_to_wsrep_flags(trx.flags()),
                             &meta,
                             &unused,
                             false));
-                    if (WSREP_OK != rcode)
+                    if (WSREP_CB_SUCCESS != rcode)
                     {
                         gu_throw_fatal << "Rollback failed. Trx: " << trx;
                     }
@@ -449,7 +449,7 @@ void galera::ReplicatorSMM::apply_trx(void* recv_ctx, TrxHandle* trx)
             &exit_loop,
             true));
 
-    if (gu_unlikely (rcode > 0))
+    if (gu_unlikely (rcode != WSREP_CB_SUCCESS))
         gu_throw_fatal << "Commit failed. Trx: " << trx;
 
     if (gu_likely(co_mode_ != CommitOrder::BYPASS))
@@ -871,7 +871,7 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandle* trx, void* trx_ctx)
                     &unused,
                     true));
 
-            if (gu_unlikely(rcode > 0))
+            if (gu_unlikely(rcode != WSREP_CB_SUCCESS))
                 gu_throw_fatal << "Commit failed. Trx: " << trx;
         }
         catch (gu::Exception& e)

--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -39,17 +39,16 @@ SavedState::SavedState  (const std::string& file) :
 
     if (ifs.fail())
     {
-        log_warn << "Could not open saved state file for reading: " << file;
+        log_warn << "Could not open state file for reading: '" << file << '\'';
     }
 
     fs_ = fopen(file.c_str(), "a");
 
     if (!fs_)
     {
-        log_warn << "Could not open saved state file for writing: " << file;
-        /* We are not reading anything from file we can't write to, since it
-           may be terribly outdated. */
-        return;
+        gu_throw_error(errno)
+            << "Could not open state file for writing: '" << file
+            << "'. Check permissions and/or disk space.";
     }
 
     // We take exclusive lock on state file in order to avoid possibility

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -90,7 +90,6 @@ extern "C"
 void galera_tear_down(wsrep_t* gh)
 {
     assert(gh != 0);
-    assert(gh->ctx != 0);
 
     REPL_CLASS * repl(reinterpret_cast< REPL_CLASS * >(gh->ctx));
 

--- a/galerautils/src/gu_fdesc.cpp
+++ b/galerautils/src/gu_fdesc.cpp
@@ -102,7 +102,7 @@ namespace gu
         }
 */
 #endif
-        log_debug << "Opened file '" << name_ << "'";
+        log_debug << "Opened file '" << name_ << "', size: " << size_;
         log_debug << "File descriptor: " << fd_;
     }
 

--- a/galerautils/src/gu_log.h
+++ b/galerautils/src/gu_log.h
@@ -70,7 +70,7 @@ extern gu_log_severity_t gu_log_max_level;
 #if !defined(__cplusplus) || defined(GALERA_LOG_H_ENABLE_CXX)
 // NOTE: don't add "\n" here even if you really want to do it
 #define GU_LOG_C(level, ...)\
-        gu_log(level, __FILE__, __PRETTY_FUNCTION__, __LINE__,\
+        gu_log(level, __FILE__, __func__, __LINE__,\
                __VA_ARGS__, NULL)
 
 /**

--- a/garb/files/freebsd/garb.sh
+++ b/garb/files/freebsd/garb.sh
@@ -63,14 +63,11 @@ garb_prestart()
 
 	GALERA_PORT=${GALERA_PORT:-4567}
 
-	# Find a working node
-	for ADDRESS in ${garb_galera_nodes} 0; do
-		HOST=$(echo $ADDRESS | cut -d \: -f 1)
-		PORT=$(echo $ADDRESS | cut -d \: -f 2)
-		PORT=${PORT:-$GALERA_PORT}
-		nc -z $HOST $PORT >/dev/null 2>&1 && break
+	# Concatenate all nodes in the list (for backward compatibility)
+	ADDRESS=
+	for NODE in ${garb_galera_nodes}; do
+		[ -z "$ADDRESS" ] && ADDRESS="$NODE" || ADDRESS="$ADDRESS,$NODE"
 	done
-	[ ${ADDRESS} == "0" ] && err 1 "None of the nodes in $garb_galera_nodes is accessible"
 
 	command_args="$command_args -a gcomm://$ADDRESS"
 	[ -n "$garb_galera_group" ]   && command_args="$command_args -g $garb_galera_group"

--- a/garb/files/garb-systemd
+++ b/garb/files/garb-systemd
@@ -23,6 +23,8 @@ start() {
 	    return 0
 	fi
 
+        [ -f $config ] && . $config
+
 	# Check that node addresses are configured
 	if [[ -z "${GALERA_NODES:-}" ]]; then
 		log_failure "List of GALERA_NODES is not configured"

--- a/garb/files/garb-systemd
+++ b/garb/files/garb-systemd
@@ -12,7 +12,7 @@ log_failure() {
 
 program_start() {
 	echo "Starting garbd"
-        /usr/bin/garbd $* 
+        /usr/bin/garbd "$@"
 }
 
 
@@ -35,31 +35,14 @@ start() {
 
 	GALERA_PORT=${GALERA_PORT:-4567}
 
-	# Find a working node
-	for ADDRESS in ${GALERA_NODES} 0; do
-		HOST=$(echo $ADDRESS | cut -d \: -f 1 )
-		PORT=$(echo $ADDRESS | cut -d \: -f 2 )
-		PORT=${PORT:-$GALERA_PORT}
-		if [[ -x `which nc` ]] && nc -h 2>&1 | grep -q  -- '-z';then
-                    nc -z $HOST $PORT >/dev/null && break
-                elif [[ -x `which nmap` ]];then
-                    nmap -Pn -p$PORT $HOST | awk "\$1 ~ /$PORT/ {print \$2}" | grep -q open && break
-                else
-                    log_failure "Neither netcat nor nmap are present for zero I/O scanning"
-                    return 1
-                fi
-	done
-	if [ ${ADDRESS} == "0" ]; then
-		log_failure "None of the nodes in $GALERA_NODES is accessible"
-		return 1
-	fi
+	OPTIONS="-d -a gcomm://${GALERA_NODES// /,}"
+	# substitute space with comma for backward compatibility
 
-	OPTIONS=" -a gcomm://$ADDRESS "
-	[ -n "${GALERA_GROUP:-}" ]   && OPTIONS="$OPTIONS -g $GALERA_GROUP"
-	[ -n "${GALERA_OPTIONS:-}" ] && OPTIONS="$OPTIONS -o $GALERA_OPTIONS"
-	[ -n "${LOG_FILE:-}" ]       && OPTIONS="$OPTIONS -l $LOG_FILE"
+	[ -n "${GALERA_GROUP:-}" ]   && OPTIONS="$OPTIONS -g '$GALERA_GROUP'"
+	[ -n "${GALERA_OPTIONS:-}" ] && OPTIONS="$OPTIONS -o '$GALERA_OPTIONS'"
+	[ -n "${LOG_FILE:-}" ]       && OPTIONS="$OPTIONS -l '$LOG_FILE'"
 
-	program_start $OPTIONS
+	eval program_start $OPTIONS
 }
 
 

--- a/garb/files/garb.cnf
+++ b/garb/files/garb.cnf
@@ -1,14 +1,14 @@
 # Copyright (C) 2012 Codership Oy
 # This config file is to be sourced by garb service script.
 
-# A space-separated list of node addresses (address[:port]) in the cluster
+# A comma-separated list of node addresses (address[:port]) in the cluster
 # GALERA_NODES=""
 
 # Galera cluster name, should be the same as on the rest of the nodes.
 # GALERA_GROUP=""
 
 # Optional Galera internal options string (e.g. SSL settings)
-# see http://www.codership.com/wiki/doku.php?id=galera_parameters
+# see http://galeracluster.com/documentation-webpages/galeraparameters.html
 # GALERA_OPTIONS=""
 
 # Log file for garbd. Optional, by default logs to syslog

--- a/garb/files/garb.sh
+++ b/garb/files/garb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2012-2013 Codership Oy <info@codership.com>
+# Copyright (C) 2012-2015 Codership Oy <info@codership.com>
 #
 # init.d script for garbd
 #
@@ -49,19 +49,23 @@ program_start() {
 	local rcode
 	if [ -f /etc/redhat-release ]; then
 		echo -n $"Starting $prog: "
-                daemon --user nobody $prog $* >/dev/null
+		daemon --user nobody $prog "$@" >/dev/null
 		rcode=$?
-		[ $rcode -eq 0 ] && pidof $prog > $PIDFILE \
-		&& echo_success || echo_failure
+		if [ $rcode -eq 0 ]; then
+			pidof $prog > $PIDFILE || rcode=$?
+		fi
+		[ $rcode -eq 0 ] && echo_success || echo_failure
 		echo
 	else
 		log_daemon_msg "Starting $prog: "
 		start-stop-daemon --start --quiet -c nobody --background \
-		                  --exec $prog -- $*
+		                  --exec $prog -- "$@"
 		rcode=$?
 		# Hack: sleep a bit to give garbd some time to fork
 		sleep 1
-		[ $rcode -eq 0 ] && pidof $prog > $PIDFILE
+		if [ $rcode -eq 0 ]; then
+			pidof $prog > $PIDFILE || rcode=$?
+		fi
 		log_end_msg $rcode
 	fi
 	return $rcode
@@ -74,7 +78,6 @@ program_stop() {
 		killproc -p $PIDFILE
 		rcode=$?
 		[ $rcode -eq 0 ] && echo_success || echo_failure
-#		echo
 	else
 		start-stop-daemon --stop --quiet --oknodo --retry TERM/30/KILL/5 \
 		                  --pidfile $PIDFILE
@@ -103,8 +106,13 @@ start() {
 	fi
 
 	if [ -r $PIDFILE ]; then
-		log_failure "$prog is already running with PID $(cat ${PIDFILE})"
-		return 3 # ESRCH
+		local PID=$(cat ${PIDFILE})
+		if ps -p $PID >/dev/null 2>&1; then
+			log_failure "$prog is already running with PID $PID"
+			return 3 # ESRCH
+		else
+			rm -f $PIDFILE
+		fi
 	fi
 
 	[ -x $prog ] || return 5
@@ -121,31 +129,14 @@ start() {
 
 	GALERA_PORT=${GALERA_PORT:-4567}
 
-	# Find a working node
-	for ADDRESS in ${GALERA_NODES} 0; do
-		HOST=$(echo $ADDRESS | cut  -d \: -f 1 )
-		PORT=$(echo $ADDRESS | cut -sd \: -f 2 )
-		PORT=${PORT:-$GALERA_PORT}
-		if [[ -x `which nc` ]] && nc -h 2>&1 | grep -q  -- '-z';then
-                    nc -z $HOST $PORT >/dev/null && break
-                elif [[ -x `which nmap` ]];then
-                    nmap -Pn -p$PORT $HOST | awk "\$1 ~ /$PORT/ {print \$2}" | grep -q open && break
-                else
-                    log_failure "Neither netcat nor nmap are present for zero I/O scanning"
-                    return 1
-                fi
-	done
-	if [ ${ADDRESS} == "0" ]; then
-		log_failure "None of the nodes in $GALERA_NODES is accessible"
-		return 1
-	fi
+	OPTIONS="-d -a gcomm://${GALERA_NODES// /,}"
+	# substitute space with comma for backward compatibility
 
-	OPTIONS="-d -a gcomm://$ADDRESS"
-	[ -n "$GALERA_GROUP" ]   && OPTIONS="$OPTIONS -g $GALERA_GROUP"
-	[ -n "$GALERA_OPTIONS" ] && OPTIONS="$OPTIONS -o $GALERA_OPTIONS"
-	[ -n "$LOG_FILE" ]       && OPTIONS="$OPTIONS -l $LOG_FILE"
+	[ -n "$GALERA_GROUP" ]   && OPTIONS="$OPTIONS -g '$GALERA_GROUP'"
+	[ -n "$GALERA_OPTIONS" ] && OPTIONS="$OPTIONS -o '$GALERA_OPTIONS'"
+	[ -n "$LOG_FILE" ]       && OPTIONS="$OPTIONS -l '$LOG_FILE'"
 
-	program_start $OPTIONS
+	eval program_start $OPTIONS
 }
 
 stop() {
@@ -184,4 +175,3 @@ case "$1" in
 	exit 2
 esac
 
-exit 0

--- a/garb/files/garb.sh
+++ b/garb/files/garb.sh
@@ -21,6 +21,10 @@
 #                    extra node to arbitrate split brain situations.
 ### END INIT INFO
 
+# On Debian Jessie, avoid redirecting calls to this script to 'systemctl start'
+
+_SYSTEMCTL_SKIP_REDIRECT=true
+
 # Source function library.
 if [ -f /etc/redhat-release ]; then
 	. /etc/init.d/functions

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -103,29 +103,29 @@ namespace gcache
         {
         public:
 
-            Buffer() : seqno_g_(), ptr_(), size_(), seqno_d_() { }
+            Buffer() : seqno_g_(), seqno_d_(), ptr_(), size_() { }
 
             Buffer (const Buffer& other)
                 :
                 seqno_g_(other.seqno_g_),
+                seqno_d_(other.seqno_d_),
                 ptr_    (other.ptr_),
-                size_   (other.size_),
-                seqno_d_(other.seqno_d_)
+                size_   (other.size_)
             { }
 
             Buffer& operator= (const Buffer& other)
             {
                 seqno_g_ = other.seqno_g_;
+                seqno_d_ = other.seqno_d_;
                 ptr_     = other.ptr_;
                 size_    = other.size_;
-                seqno_d_ = other.seqno_d_;
                 return *this;
             }
 
             int64_t           seqno_g() const { return seqno_g_; }
-            const gu::byte_t* ptr()     const { return ptr_;     }
-            ssize_t           size()    const { return size_;    }
             int64_t           seqno_d() const { return seqno_d_; }
+            const gu::byte_t* ptr()     const { return ptr_;     }
+            ssize_type        size()    const { return size_;    }
 
         protected:
 
@@ -134,15 +134,18 @@ namespace gcache
                 ptr_ = reinterpret_cast<const gu::byte_t*>(p);
             }
 
-            void set_other (ssize_t s, int64_t g, int64_t d)
-            { size_ = s; seqno_g_ = g; seqno_d_ = d; }
+            void set_other (int64_t g, int64_t d, ssize_type s)
+            {
+                assert(s > 0);
+                seqno_g_ = g; seqno_d_ = d; size_ = s;
+            }
 
         private:
 
             int64_t           seqno_g_;
-            const gu::byte_t* ptr_;
-            ssize_t           size_;
             int64_t           seqno_d_;
+            const gu::byte_t* ptr_;
+            ssize_type        size_; /* same type as passed to malloc() */
 
             friend class GCache;
         };
@@ -154,8 +157,7 @@ namespace gcache
          *
          * @retval number of buffers filled (<= v.size())
          */
-        ssize_t seqno_get_buffers (std::vector<Buffer>& v,
-                                   int64_t start);
+        size_t seqno_get_buffers (std::vector<Buffer>& v, int64_t start);
 
         /*!
          * Releases any seqno locks present.
@@ -186,23 +188,23 @@ namespace gcache
             const std::string& rb_name()  const { return rb_name_;  }
             const std::string& dir_name() const { return dir_name_; }
 
-            ssize_t mem_size()            const { return mem_size_;        }
-            ssize_t rb_size()             const { return rb_size_;         }
-            ssize_t page_size()           const { return page_size_;       }
-            ssize_t keep_pages_size()     const { return keep_pages_size_; }
+            size_t mem_size()            const { return mem_size_;        }
+            size_t rb_size()             const { return rb_size_;         }
+            size_t page_size()           const { return page_size_;       }
+            size_t keep_pages_size()     const { return keep_pages_size_; }
 
-            void mem_size        (ssize_t s) { mem_size_        = s; }
-            void page_size       (ssize_t s) { page_size_       = s; }
-            void keep_pages_size (ssize_t s) { keep_pages_size_ = s; }
+            void mem_size        (size_t s) { mem_size_        = s; }
+            void page_size       (size_t s) { page_size_       = s; }
+            void keep_pages_size (size_t s) { keep_pages_size_ = s; }
 
         private:
 
             std::string const rb_name_;
             std::string const dir_name_;
-            ssize_t           mem_size_;
-            ssize_t     const rb_size_;
-            ssize_t           page_size_;
-            ssize_t           keep_pages_size_;
+            size_t            mem_size_;
+            size_t      const rb_size_;
+            size_t            page_size_;
+            size_t            keep_pages_size_;
         }
             params;
 

--- a/gcache/src/GCache.hpp
+++ b/gcache/src/GCache.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2009-2015 Codership Oy <info@codership.com>
  */
 
 #ifndef __GCACHE_H__
@@ -47,9 +47,10 @@ namespace gcache
         void  reset();
 
         /* Memory allocation functions */
-        void* malloc  (int size);
+        typedef MemOps::ssize_type ssize_type;
+        void* malloc  (ssize_type size);
         void  free    (void* ptr);
-        void* realloc (void* ptr, int size);
+        void* realloc (void* ptr, ssize_type size);
 
         /* Seqno related functions */
 
@@ -167,6 +168,8 @@ namespace gcache
         static size_t const PREAMBLE_LEN;
 
     private:
+
+        typedef MemOps::size_type size_type;
 
         void free_common (BufferHeader*);
 

--- a/gcache/src/GCache_seqno.cpp
+++ b/gcache/src/GCache_seqno.cpp
@@ -244,7 +244,7 @@ namespace gcache
                 seqno_locked = start;
 
                 do {
-                    assert (p->first == (start + found));
+                    assert (p->first == int64_t(start + found));
                     assert (p->second);
                     v[found].set_ptr(p->second);
                 }
@@ -259,7 +259,7 @@ namespace gcache
         {
             const BufferHeader* const bh (ptr2BH(v[i].ptr()));
 
-            assert (bh->seqno_g == (start + i));
+            assert (bh->seqno_g == int64_t(start + i));
             Limits::assert_size(bh->size);
 
             v[i].set_other (bh->seqno_g,

--- a/gcache/src/gcache_bh.hpp
+++ b/gcache/src/gcache_bh.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2009-2015 Codership Oy <info@codership.com>
  *
  */
 
@@ -9,6 +9,7 @@
 #include "SeqnoNone.hpp"
 #include "gcache_memops.hpp"
 #include <gu_assert.h>
+#include <gu_macros.hpp>
 
 #include <cstring>
 #include <stdint.h>
@@ -29,11 +30,14 @@ namespace gcache
     {
         int64_t  seqno_g;
         int64_t  seqno_d;
-        int64_t  size;    /*! total buffer size, including header */
+        uint64_t size;    /*! total buffer size, including header */
         MemOps*  ctx;
         uint32_t flags;
         int32_t  store;
     }__attribute__((__packed__));
+
+    GU_COMPILE_ASSERT(sizeof(BufferHeader::size) >= sizeof(MemOps::size_type),
+                      buffer_header_size_check);
 
 #define BH_cast(ptr) reinterpret_cast<BufferHeader*>(ptr)
 
@@ -89,7 +93,6 @@ namespace gcache
            << ". store: "   << bh->store;
         return os;
     }
-
 }
 
 #endif /* __GCACHE_BUFHEAD__ */

--- a/gcache/src/gcache_bh.hpp
+++ b/gcache/src/gcache_bh.hpp
@@ -36,7 +36,7 @@ namespace gcache
         int32_t  store;
     }__attribute__((__packed__));
 
-    GU_COMPILE_ASSERT(sizeof(BufferHeader::size) >= sizeof(MemOps::size_type),
+    GU_COMPILE_ASSERT(sizeof(BufferHeader().size) >= sizeof(MemOps::size_type),
                       buffer_header_size_check);
 
 #define BH_cast(ptr) reinterpret_cast<BufferHeader*>(ptr)

--- a/gcache/src/gcache_limits.hpp
+++ b/gcache/src/gcache_limits.hpp
@@ -27,7 +27,7 @@ namespace gcache
 
         static size_type const MIN_SIZE = sizeof(BufferHeader) + 1;
 
-        static inline void assert_size(size_type s)
+        static inline void assert_size(unsigned long long s)
         {
 #ifndef NDEBUG
             assert(s <= MAX_SIZE);

--- a/gcache/src/gcache_limits.hpp
+++ b/gcache/src/gcache_limits.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 Codership Oy <info@codership.com>
+ */
+
+/*! @file memory operations interface */
+
+#ifndef _gcache_limits_hpp_
+#define _gcache_limits_hpp_
+
+#include "gcache_bh.hpp"
+#include <gu_macros.hpp> // GU_COMPILE_ASSERT
+#include <limits>
+
+namespace gcache
+{
+    class Limits
+    {
+    public:
+
+        typedef MemOps::size_type  size_type;
+        typedef MemOps::ssize_type ssize_type;
+
+        static ssize_type const SSIZE_MAX_ =
+            (1ULL << (sizeof(ssize_type)*8 - 1)) - 1;
+
+        static size_type const MAX_SIZE = sizeof(BufferHeader) + SSIZE_MAX_;
+
+        static size_type const MIN_SIZE = sizeof(BufferHeader) + 1;
+
+        static inline void assert_size(size_type s)
+        {
+#ifndef NDEBUG
+            assert(s <= MAX_SIZE);
+            assert(s >= MIN_SIZE);
+#endif /* NDEBUG */
+        }
+
+    private:
+
+        /* the difference between MAX_SIZE and MIN_SIZE should never exceed
+         * diff_type capacity */
+
+        typedef MemOps::diff_type diff_type;
+
+        static diff_type const DIFF_MAX =
+            (1ULL << (sizeof(diff_type)*8 - 1)) - 1;
+
+        GU_COMPILE_ASSERT(DIFF_MAX >= MAX_SIZE - MIN_SIZE, max_diff);
+
+        static diff_type const DIFF_MIN = -DIFF_MAX - 1;
+
+        typedef long long long_long;
+
+        GU_COMPILE_ASSERT(DIFF_MIN <=long_long(MIN_SIZE - MAX_SIZE), min_diff);
+
+    }; /* class Limits */
+}
+
+#endif /* _gcache_limits_hpp_ */

--- a/gcache/src/gcache_limits.hpp
+++ b/gcache/src/gcache_limits.hpp
@@ -40,12 +40,15 @@ namespace gcache
         /* the difference between MAX_SIZE and MIN_SIZE should never exceed
          * diff_type capacity */
 
+        GU_COMPILE_ASSERT(MAX_SIZE > MIN_SIZE, max_min);
+
         typedef MemOps::diff_type diff_type;
 
         static diff_type const DIFF_MAX =
             (1ULL << (sizeof(diff_type)*8 - 1)) - 1;
 
-        GU_COMPILE_ASSERT(DIFF_MAX >= MAX_SIZE - MIN_SIZE, max_diff);
+        GU_COMPILE_ASSERT(DIFF_MAX >= 0, diff_max);
+        GU_COMPILE_ASSERT(size_type(DIFF_MAX) >= MAX_SIZE - MIN_SIZE, max_diff);
 
         static diff_type const DIFF_MIN = -DIFF_MAX - 1;
 

--- a/gcache/src/gcache_mem_store.cpp
+++ b/gcache/src/gcache_mem_store.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 #include "gcache_mem_store.hpp"
@@ -11,7 +11,7 @@ namespace gcache
 {
 
 bool
-MemStore::have_free_space (ssize_t size)
+MemStore::have_free_space (size_type size)
 {
     while ((size_ + size > max_size_) && !seqno2ptr_.empty())
     {

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file mem store class */
@@ -9,6 +9,7 @@
 
 #include "gcache_memops.hpp"
 #include "gcache_bh.hpp"
+#include "gcache_limits.hpp"
 
 #include <string>
 #include <set>
@@ -44,8 +45,10 @@ namespace gcache
 
         ~MemStore () { reset(); }
 
-        void* malloc  (int size)
+        void* malloc  (size_type size)
         {
+            Limits::assert_size(size);
+
             if (size > max_size_ || have_free_space(size) == false) return 0;
 
             assert (size_ + size <= max_size_);
@@ -81,10 +84,10 @@ namespace gcache
             if (SEQNO_NONE == bh->seqno_g) discard (bh);
         }
 
-        void* realloc (void* ptr, int size)
+        void* realloc (void* ptr, size_type size)
         {
             BufferHeader* bh(0);
-            ssize_t old_size(0);
+            size_type old_size(0);
 
             if (ptr)
             {
@@ -93,7 +96,7 @@ namespace gcache
                 old_size = bh->size;
             }
 
-            ssize_t const diff_size(size - old_size);
+            diff_type const diff_size(size - old_size);
 
             if (size > max_size_ ||
                 have_free_space(diff_size) == false) return 0;
@@ -128,7 +131,7 @@ namespace gcache
             allocd_.erase(bh);
         }
 
-        void set_max_size (ssize_t size) { max_size_ = size; }
+        void set_max_size (size_t size) { max_size_ = size; }
 
         void seqno_reset();
 
@@ -137,10 +140,10 @@ namespace gcache
 
     private:
 
-        bool have_free_space (ssize_t size);
+        bool have_free_space (size_type size);
 
-        ssize_t         max_size_;
-        ssize_t         size_;
+        size_t          max_size_;
+        size_t          size_;
         std::set<void*> allocd_;
         seqno2ptr_t&    seqno2ptr_;
     };

--- a/gcache/src/gcache_mem_store.hpp
+++ b/gcache/src/gcache_mem_store.hpp
@@ -24,7 +24,7 @@ namespace gcache
 
     public:
 
-        MemStore (ssize_t max_size, seqno2ptr_t& seqno2ptr)
+        MemStore (size_t max_size, seqno2ptr_t& seqno2ptr)
             : max_size_ (max_size),
               size_     (0),
               allocd_   (),
@@ -136,7 +136,7 @@ namespace gcache
         void seqno_reset();
 
         // for unit tests only
-        ssize_t _allocd () const { return size_; }
+        size_t _allocd () const { return size_; }
 
     private:
 

--- a/gcache/src/gcache_memops.hpp
+++ b/gcache/src/gcache_memops.hpp
@@ -1,11 +1,13 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file memory operations interface */
 
 #ifndef _gcache_memops_hpp_
 #define _gcache_memops_hpp_
+
+#include <limits>
 
 namespace gcache
 {
@@ -14,17 +16,27 @@ namespace gcache
     class MemOps
     {
     public:
+
+        /* although size value passed to GCache should be representable by
+         * a signed integer type, internally the buffer allocated will also
+         * incur header overhead, so it has to be represented by unsigned int.
+         * However the difference between to internal sizes should never exceed
+         * signed representation. */
+        typedef          int ssize_type; // size passed to GCache
+        typedef unsigned int size_type;  // internal size representation
+        typedef ssize_type   diff_type;  // difference between two size_types
+
         MemOps() {}
         virtual ~MemOps() {}
 
         virtual void*
-        malloc  (int size)                = 0;
+        malloc  (size_type size)          = 0;
 
         virtual void
         free    (BufferHeader* bh)        = 0;
 
         virtual void*
-        realloc (void* ptr, int size)     = 0;
+        realloc (void* ptr, size_type size) = 0;
 
         virtual void
         discard (BufferHeader* bh)        = 0;

--- a/gcache/src/gcache_page.cpp
+++ b/gcache/src/gcache_page.cpp
@@ -76,12 +76,13 @@ gcache::Page::malloc (size_type size)
         bh->flags   = 0;
         bh->store   = BUFFER_IN_PAGE;
 
+        assert(space_ >= size);
         space_ -= size;
         next_  += size;
         used_++;
 
 #ifndef NDEBUG
-        if (space_ >= static_cast<ssize_t>(sizeof(BufferHeader)))
+        if (space_ >= sizeof(BufferHeader))
         {
             BH_clear (BH_cast(next_));
             assert (reinterpret_cast<uint8_t*>(bh + 1) < next_);
@@ -111,7 +112,7 @@ gcache::Page::realloc (void* ptr, size_type size)
     {
         diff_type const diff_size (size - bh->size);
 
-        if (gu_likely (diff_size < space_))
+        if (gu_likely (diff_size < 0 || size_t(diff_size) < space_))
         {
             bh->size += diff_size;
             space_   -= diff_size;
@@ -131,6 +132,7 @@ gcache::Page::realloc (void* ptr, size_type size)
             if (ret)
             {
                 memcpy (ret, ptr, bh->size - sizeof(BufferHeader));
+                assert(used_ > 0);
                 used_--;
             }
 

--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -40,9 +40,9 @@ namespace gcache
 
         void discard (BufferHeader* ptr) {}
 
-        ssize_t used () const { return used_; }
+        size_t used () const { return used_; }
 
-        ssize_t size () const /* total page size */
+        size_t size () const /* total page size */
         { return mmap_.size - sizeof(BufferHeader); }
 
         const std::string& name() const { return fd_.name(); }
@@ -60,8 +60,8 @@ namespace gcache
         gu::MMap           mmap_;
         void* const        ps_;
         uint8_t*           next_;
-        ssize_t            space_;
-        ssize_t            used_;
+        size_t             space_;
+        size_t             used_;
 
         Page(const gcache::Page&);
         Page& operator=(const gcache::Page&);

--- a/gcache/src/gcache_page.hpp
+++ b/gcache/src/gcache_page.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file page file class */
@@ -21,10 +21,10 @@ namespace gcache
     {
     public:
 
-        Page (void* ps, const std::string& name, ssize_t size);
+        Page (void* ps, const std::string& name, size_t size);
         ~Page () {}
 
-        void* malloc  (int size);
+        void* malloc  (size_type size);
 
         void  free    (BufferHeader* bh)
         {
@@ -36,7 +36,7 @@ namespace gcache
             used_--;
         }
 
-        void* realloc (void* ptr, int size);
+        void* realloc (void* ptr, size_type size);
 
         void discard (BufferHeader* ptr) {}
 

--- a/gcache/src/gcache_page_store.cpp
+++ b/gcache/src/gcache_page_store.cpp
@@ -40,7 +40,7 @@ make_base_name (const std::string& dir_name)
 }
 
 static std::string
-make_page_name (const std::string& base_name, ssize_t count)
+make_page_name (const std::string& base_name, size_t count)
 {
     std::ostringstream os;
     os << base_name << std::setfill ('0') << std::setw (6) << count;

--- a/gcache/src/gcache_page_store.cpp
+++ b/gcache/src/gcache_page_store.cpp
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file page store implementation */
 
 #include "gcache_page_store.hpp"
 #include "gcache_bh.hpp"
+#include "gcache_limits.hpp"
 
 #include <gu_logger.hpp>
 #include <gu_throw.hpp>
@@ -128,7 +129,7 @@ gcache::PageStore::reset ()
 }
 
 inline void
-gcache::PageStore::new_page (ssize_t size)
+gcache::PageStore::new_page (size_type size)
 {
     Page* const page(new Page(this, make_page_name (base_name_, count_), size));
 
@@ -139,8 +140,8 @@ gcache::PageStore::new_page (ssize_t size)
 }
 
 gcache::PageStore::PageStore (const std::string& dir_name,
-                              ssize_t            keep_size,
-                              ssize_t            page_size,
+                              size_t             keep_size,
+                              size_t             page_size,
                               bool               keep_page)
     :
     base_name_ (make_base_name(dir_name)),
@@ -200,9 +201,11 @@ gcache::PageStore::~PageStore ()
 }
 
 inline void*
-gcache::PageStore::malloc_new (unsigned int size)
+gcache::PageStore::malloc_new (size_type size)
 {
-    void* ret = 0;
+    Limits::assert_size(size);
+
+    void* ret(NULL);
 
     try
     {
@@ -221,11 +224,13 @@ gcache::PageStore::malloc_new (unsigned int size)
 }
 
 void*
-gcache::PageStore::malloc (int size)
+gcache::PageStore::malloc (size_type const size)
 {
+    Limits::assert_size(size);
+
     if (gu_likely (0 != current_))
     {
-        register void* ret = current_->malloc (size);
+        void* ret = current_->malloc (size);
 
         if (gu_likely(0 != ret)) return ret;
 
@@ -236,9 +241,11 @@ gcache::PageStore::malloc (int size)
 }
 
 void*
-gcache::PageStore::realloc (void* ptr, int size)
+gcache::PageStore::realloc (void* ptr, size_type const size)
 {
-    assert(ptr != 0);
+    Limits::assert_size(size);
+
+    assert(ptr != NULL);
 
     BufferHeader* const bh(ptr2BH(ptr));
     Page* const page(static_cast<Page*>(bh->ctx));
@@ -251,7 +258,8 @@ gcache::PageStore::realloc (void* ptr, int size)
 
     if (gu_likely(0 != ret))
     {
-        ssize_t const ptr_size(bh->size - sizeof(BufferHeader));
+        assert(bh->size > sizeof(BufferHeader));
+        size_type const ptr_size(bh->size - sizeof(BufferHeader));
 
         memcpy (ret, ptr, size > ptr_size ? ptr_size : size);
         free_page_ptr (page, bh);

--- a/gcache/src/gcache_page_store.hpp
+++ b/gcache/src/gcache_page_store.hpp
@@ -46,11 +46,11 @@ namespace gcache
 
         void  reset();
 
-        ssize_t count() const { return count_; } // for unit tests
+        size_t count() const { return count_; } // for unit tests
 
-        void  set_page_size (ssize_t size) { page_size_ = size; }
+        void  set_page_size (size_t size) { page_size_ = size; }
 
-        void  set_keep_size (ssize_t size) { keep_size_ = size; }
+        void  set_keep_size (size_t size) { keep_size_ = size; }
 
     private:
 
@@ -58,7 +58,7 @@ namespace gcache
         size_t            keep_size_; /* how much pages to keep after freeing*/
         size_t            page_size_; /* min size of the individual page */
         bool        const keep_page_; /* whether to keep the last page */
-        int               count_;
+        size_t            count_;
         std::deque<Page*> pages_;
         Page*             current_;
         size_t            total_size_;

--- a/gcache/src/gcache_page_store.hpp
+++ b/gcache/src/gcache_page_store.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file page store class */
@@ -20,8 +20,8 @@ namespace gcache
     public:
 
         PageStore (const std::string& dir_name,
-                   ssize_t            keep_size,
-                   ssize_t            page_size,
+                   size_t             keep_size,
+                   size_t             page_size,
                    bool               keep_page);
 
         ~PageStore ();
@@ -31,11 +31,11 @@ namespace gcache
             return static_cast<PageStore*>(p->parent());
         }
 
-        void* malloc  (int size);
+        void* malloc  (size_type size);
 
         void  free    (BufferHeader* bh) { assert(0); }
 
-        void* realloc (void* ptr, int size);
+        void* realloc (void* ptr, size_type size);
 
         void  discard (BufferHeader* bh)
         {
@@ -55,19 +55,19 @@ namespace gcache
     private:
 
         std::string const base_name_; /* /.../.../gcache.page. */
-        ssize_t           keep_size_; /* how much pages to keep after freeing*/
-        ssize_t           page_size_; /* min size of the individual page */
+        size_t            keep_size_; /* how much pages to keep after freeing*/
+        size_t            page_size_; /* min size of the individual page */
         bool        const keep_page_; /* whether to keep the last page */
-        ssize_t           count_;
+        int               count_;
         std::deque<Page*> pages_;
         Page*             current_;
-        ssize_t           total_size_;
+        size_t            total_size_;
         pthread_attr_t    delete_page_attr_;
 #ifndef GCACHE_DETACH_THREAD
         pthread_t         delete_thr_;
 #endif /* GCACHE_DETACH_THREAD */
 
-        void new_page    (ssize_t size);
+        void new_page    (size_type size);
 
         // returns true if a page could be deleted
         bool delete_page ();
@@ -75,7 +75,7 @@ namespace gcache
         // cleans up extra pages.
         void cleanup     ();
 
-        void* malloc_new (unsigned int size);
+        void* malloc_new (size_type size);
 
         void
         free_page_ptr (Page* page, BufferHeader* bh)

--- a/gcache/src/gcache_params.cpp
+++ b/gcache/src/gcache_params.cpp
@@ -57,10 +57,10 @@ gcache::GCache::Params::Params (gu::Config& cfg, const std::string& data_dir)
     :
     rb_name_  (name_value (cfg, data_dir)),
     dir_name_ (cfg.get(GCACHE_PARAMS_DIR)),
-    mem_size_ (cfg.get<ssize_t>(GCACHE_PARAMS_MEM_SIZE)),
-    rb_size_  (cfg.get<ssize_t>(GCACHE_PARAMS_RB_SIZE)),
-    page_size_(cfg.get<ssize_t>(GCACHE_PARAMS_PAGE_SIZE)),
-    keep_pages_size_(cfg.get<ssize_t>(GCACHE_PARAMS_KEEP_PAGES_SIZE))
+    mem_size_ (cfg.get<size_t>(GCACHE_PARAMS_MEM_SIZE)),
+    rb_size_  (cfg.get<size_t>(GCACHE_PARAMS_RB_SIZE)),
+    page_size_(cfg.get<size_t>(GCACHE_PARAMS_PAGE_SIZE)),
+    keep_pages_size_(cfg.get<size_t>(GCACHE_PARAMS_KEEP_PAGES_SIZE))
 {}
 
 void
@@ -76,16 +76,13 @@ gcache::GCache::param_set (const std::string& key, const std::string& val)
     }
     else if (key == GCACHE_PARAMS_MEM_SIZE)
     {
-        ssize_t tmp_size = gu::Config::from_config<ssize_t>(val);
-
-        if (tmp_size < 0)
-            gu_throw_error(EINVAL) << "Negative memory buffer size";
+        size_t tmp_size = gu::Config::from_config<size_t>(val);
 
         gu::Lock lock(mtx);
         /* locking here serves two purposes: ensures atomic setting of config
          * and params.ram_size and syncs with malloc() method */
 
-        config.set<ssize_t>(key, tmp_size);
+        config.set<size_t>(key, tmp_size);
         params.mem_size(tmp_size);
         mem.set_max_size(params.mem_size());
     }
@@ -95,31 +92,25 @@ gcache::GCache::param_set (const std::string& key, const std::string& val)
     }
     else if (key == GCACHE_PARAMS_PAGE_SIZE)
     {
-        ssize_t tmp_size = gu::Config::from_config<ssize_t>(val);
-
-        if (tmp_size < 0)
-            gu_throw_error(EINVAL) << "Negative page buffer size";
+        size_t tmp_size = gu::Config::from_config<size_t>(val);
 
         gu::Lock lock(mtx);
         /* locking here serves two purposes: ensures atomic setting of config
          * and params.ram_size and syncs with malloc() method */
 
-        config.set<ssize_t>(key, tmp_size);
+        config.set<size_t>(key, tmp_size);
         params.page_size(tmp_size);
         ps.set_page_size(params.page_size());
     }
     else if (key == GCACHE_PARAMS_KEEP_PAGES_SIZE)
     {
-        ssize_t tmp_size = gu::Config::from_config<ssize_t>(val);
-
-        if (tmp_size < 0)
-            gu_throw_error(EINVAL) << "Negative keep pages size";
+        size_t tmp_size = gu::Config::from_config<size_t>(val);
 
         gu::Lock lock(mtx);
         /* locking here serves two purposes: ensures atomic setting of config
          * and params.ram_size and syncs with malloc() method */
 
-        config.set<ssize_t>(key, tmp_size);
+        config.set<size_t>(key, tmp_size);
         params.keep_pages_size(tmp_size);
         ps.set_keep_size(params.keep_pages_size());
     }

--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -145,9 +145,10 @@ namespace gcache
         }
 
         assert (ret <= first_);
-        if ((first_ - ret) >= size_next) { assert(size_free_ >= size); }
 
-        while ((first_ - ret) < size_next) {
+        if (first_ >= ret + size_next) { assert(size_free_ >= size); }
+
+        while (first_ < ret + size_next) {
             // try to discard first buffer to get more space
             BufferHeader* bh = BH_cast(first_);
 
@@ -175,10 +176,9 @@ namespace gcache
                 assert(first_ >= ret);
 
                 first_ = start_;
-// WRONG               if (first_ != ret) size_trail_ = 0; // we're now contiguous: first_ < next_
                 assert_size_free();
 
-                if ((end_ - ret) >= size_next)
+                if (end_ >= ret + size_next)
                 {
                     assert(size_free_ >= size);
                     size_trail_ = 0;
@@ -190,10 +190,12 @@ namespace gcache
                     ret = start_;
                 }
             }
+
+            assert(ret <= first_);
         }
 
 #ifndef NDEBUG
-        if ((first_ - ret) < size_next) {
+        if (first_ < ret + size_next) {
             log_fatal << "Assertion ((first - ret) >= size_next) failed: "
                       << std::endl
                       << "first offt = " << (first_ - start_) << std::endl

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -91,7 +91,7 @@ namespace gcache
             if (next_ >= first_)
                 assert(0 == size_trail_);
             else
-                assert(size_trail_ >= ssize_t(sizeof(BufferHeader)));
+                assert(size_trail_ >= sizeof(BufferHeader));
 #endif
         }
 

--- a/gcache/src/gcache_rb_store.hpp
+++ b/gcache/src/gcache_rb_store.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2010-2015 Codership Oy <info@codership.com>
  */
 
 /*! @file ring buffer storage class */
@@ -23,16 +23,16 @@ namespace gcache
     {
     public:
 
-        RingBuffer (const std::string& name, ssize_t size,
+        RingBuffer (const std::string& name, size_t size,
                     std::map<int64_t, const void*>& seqno2ptr);
 
         ~RingBuffer ();
 
-        void* malloc  (int size);
+        void* malloc  (size_type size);
 
         void  free    (BufferHeader* bh);
 
-        void* realloc (void* ptr, int size);
+        void* realloc (void* ptr, size_type size);
 
         void  discard (BufferHeader* const bh)
         {
@@ -42,9 +42,9 @@ namespace gcache
             assert (size_free_ <= size_cache_);
         }
 
-        ssize_t size      () const { return size_cache_; }
+        size_t size      () const { return size_cache_; }
 
-        ssize_t rb_size   () const { return fd_.size(); }
+        size_t rb_size   () const { return fd_.size(); }
 
         const std::string& rb_name() const { return fd_.name(); }
 
@@ -57,7 +57,7 @@ namespace gcache
 
         void print (std::ostream& os) const;
 
-        static ssize_t pad_size()
+        static size_t pad_size()
         {
             RingBuffer* rb(0);
             // cppcheck-suppress nullPointer
@@ -79,7 +79,7 @@ namespace gcache
             {
                 /* start_  next_       first_   end_
                  *   |#######|           |#####| |      */
-                assert(size_free_ >= (first_ - next_));
+                assert(size_free_ >= size_t(first_ - next_));
             }
             assert (size_free_ <= size_cache_);
 #endif
@@ -103,8 +103,8 @@ namespace gcache
 
     private:
 
-        static ssize_t const PREAMBLE_LEN = 1024;
-        static ssize_t const HEADER_LEN = 32;
+        static size_t const PREAMBLE_LEN = 1024;
+        static size_t const HEADER_LEN = 32;
 
         gu::FileDescriptor fd_;
         gu::MMap           mmap_;
@@ -116,16 +116,16 @@ namespace gcache
         uint8_t*           first_;    // pointer to the first (oldest) buffer
         uint8_t*           next_;     // pointer to the next free space
 
-        ssize_t      const size_cache_;
-        ssize_t            size_free_;
-        ssize_t            size_used_;
-        ssize_t            size_trail_;
+        size_t       const size_cache_;
+        size_t             size_free_;
+        size_t             size_used_;
+        size_t             size_trail_;
 
         typedef std::map<int64_t, const void*> seqno2ptr_t;
 
         seqno2ptr_t&    seqno2ptr_;
 
-        BufferHeader*   get_new_buffer (ssize_t size);
+        BufferHeader*   get_new_buffer (size_type size);
 
         void            constructor_common();
 

--- a/gcache/tests/gcache_rb_test.cpp
+++ b/gcache/tests/gcache_rb_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2014 Codership Oy <info@codership.com>
+ * Copyright (C) 2011-2015 Codership Oy <info@codership.com>
  *
  * $Id$
  */
@@ -13,8 +13,8 @@ using namespace gcache;
 START_TEST(test1)
 {
     std::string const rb_name = "rb_test";
-    ssize_t const bh_size = sizeof(gcache::BufferHeader);
-    ssize_t const rb_size (4 + 2*bh_size);
+    size_t const bh_size = sizeof(gcache::BufferHeader);
+    size_t const rb_size (4 + 2*bh_size);
 
     std::map<int64_t, const void*> s2p;
     RingBuffer rb(rb_name, rb_size, s2p);

--- a/scripts/packages/galera-obs.spec
+++ b/scripts/packages/galera-obs.spec
@@ -116,10 +116,7 @@ Requires(preun): initscripts
 %endif
 %endif # systemd
 
-Requires:      openssl nmap
-%if 0%{?centos} == 6
-Requires: nc
-%endif
+Requires:      openssl
 
 Provides:      wsrep, %{name} = %{version}-%{release}
 Provides:      galera, galera3, Percona-XtraDB-Cluster-galera-25


### PR DESCRIPTION
...ipts
- removes pre-3.x nc/nmap probing for live nodes in garbd system scripts
- encloses garbd parameters in single quotes and makes sure they are passed properly to the daemon start function
- removes final exit 0 in garb.sh that masked real error code
- makes sure to return error if there is no process or PID file can't be created
- removes stale PID file if found on startup instead of freaking out and forcing the user to do it manually
- removes dependency on nc/nmap from RPM spec

Note that service garb start will return 0 before garbd successfuly joins the
cluster. This is due to both potentially long wait times and forking into
daemon before the actual library initialization due to its multithreaded
character. However cluster connection errors will be logged to syslog/logfile.

Any firther improvements in error code reporting will require garbd code
refactoring.
