### PR TITLE
Refs codership/galera#270

### DIFF
--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -39,17 +39,16 @@ SavedState::SavedState  (const std::string& file) :
 
     if (ifs.fail())
     {
-        log_warn << "Could not open saved state file for reading: " << file;
+        log_warn << "Could not open state file for reading: '" << file << '\'';
     }
 
     fs_ = fopen(file.c_str(), "a");
 
     if (!fs_)
     {
-        log_warn << "Could not open saved state file for writing: " << file;
-        /* We are not reading anything from file we can't write to, since it
-           may be terribly outdated. */
-        return;
+        gu_throw_error(errno)
+            << "Could not open state file for writing: '" << file
+            << "'. Check permissions and/or disk space.";
     }
 
     // We take exclusive lock on state file in order to avoid possibility

--- a/galera/src/wsrep_provider.cpp
+++ b/galera/src/wsrep_provider.cpp
@@ -90,7 +90,6 @@ extern "C"
 void galera_tear_down(wsrep_t* gh)
 {
     assert(gh != 0);
-    assert(gh->ctx != 0);
 
     REPL_CLASS * repl(reinterpret_cast< REPL_CLASS * >(gh->ctx));
 


### PR DESCRIPTION
Galera should fail initialization if it can't open grastate.dat for writing.

Philip, I hope the pull is too trivial to require anybody else's review. See codership/galera#270 for results.
