### PR TITLE
Set _SYSTEMCTL_SKIP_REDIRECT so that /etc/init.d/garb start is not re…

### DIFF
--- a/garb/files/garb.sh
+++ b/garb/files/garb.sh
@@ -21,6 +21,10 @@
 #                    extra node to arbitrate split brain situations.
 ### END INIT INFO
 
+# On Debian Jessie, avoid redirecting calls to this script to 'systemctl start'
+
+_SYSTEMCTL_SKIP_REDIRECT=true
+
 # Source function library.
 if [ -f /etc/redhat-release ]; then
 	. /etc/init.d/functions


### PR DESCRIPTION
…directed back to 'systemctl start'
