### PR TITLE
Gh321

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -118,7 +118,7 @@ tests      = int(ARGUMENTS.get('tests', 1))
 strict_build_flags = int(ARGUMENTS.get('strict_build_flags', 1))
 
 
-GALERA_VER = ARGUMENTS.get('version', '3.12')
+GALERA_VER = ARGUMENTS.get('version', '3.13dev')
 GALERA_REV = ARGUMENTS.get('revno', 'XXXX')
 
 # Attempt to read from file if not given

--- a/SConstruct
+++ b/SConstruct
@@ -89,27 +89,23 @@ if dbug:
 
 if sysname == 'sunos':
     compile_arch = ' -mtune=native'
-    link_arch    = ''
 elif x86:
     if bits == 32:
-        compile_arch = ' -m32 -march=i686'
-        link_arch    = compile_arch
-        if sysname == 'linux':
-            link_arch = link_arch + ' -Wl,-melf_i386'
+        if machine == 'x86_64':
+            compile_arch = ' -mx32'
+        else:
+            compile_arch = ' -m32 -march=i686'
+            if sysname == 'linux':
+                link_arch = ' -Wl,-melf_i386'
     else:
         compile_arch = ' -m64'
-        link_arch    = compile_arch
         if sysname == 'linux':
-            link_arch = link_arch + ' -Wl,-melf_x86_64'
+            link_arch = ' -Wl,-melf_x86_64'
+    link_arch = compile_arch + link_arch
 elif machine == 's390x':
     compile_arch = ' -mzarch -march=z196 -mtune=zEC12'
-    link_arch    = ''
     if bits == 32:
         compile_arch += ' -m32'
-else:
-    compile_arch = ''
-    link_arch    = ''
-
 
 boost      = int(ARGUMENTS.get('boost', 1))
 boost_pool = int(ARGUMENTS.get('boost_pool', 0))

--- a/SConstruct
+++ b/SConstruct
@@ -107,7 +107,7 @@ elif machine == 's390x':
     if bits == 32:
         compile_arch += ' -m32'
 else:
-    compile_arch = ' -mtune=native'
+    compile_arch = ''
     link_arch    = ''
 
 
@@ -437,6 +437,9 @@ if not conf.CheckLib('check'):
 if not conf.CheckLib('m'):
     print 'Error: math library not found or not usable'
     Exit(1)
+
+# potential check dependency, link if present
+conf.CheckLib('subunit')
 
 if sysname != 'darwin':
     if not conf.CheckLib('rt'):

--- a/SConstruct
+++ b/SConstruct
@@ -1,8 +1,18 @@
 ###################################################################
 #
-# Copyright (C) 2010-2014 Codership Oy <info@codership.com>
+# Copyright (C) 2010-2015 Codership Oy <info@codership.com>
 #
 # SCons build script to build galera libraries
+#
+# How to control the build with environment variables:
+# Set CC       to specify C compiler
+# Set CXX      to specify C++ compiler
+# Set CPPFLAGS to add non-standard include paths and preprocessor macros
+# Set CCFLAGS  to *override* optimization and architecture-specific options
+# Set CFLAGS   to supply C compiler options
+# Set CXXFLAGS to supply C++ compiler options
+# Set LDFLAGS  to *override* linking flags
+# Set LIBPATH  to add non-standard linker paths
 #
 # Script structure:
 # - Help message
@@ -156,12 +166,16 @@ if link != 'default':
     env.Replace(LINK = link)
 
 # Initialize CPPFLAGS and LIBPATH from environment to get user preferences
-env.Replace(CPPFLAGS = os.getenv('CPPFLAGS', ''))
-env.Replace(LIBPATH = [os.getenv('LIBPATH', '')])
+env.Replace(CPPFLAGS  = os.getenv('CPPFLAGS', ''))
+env.Replace(CCFLAGS   = os.getenv('CCFLAGS',  opt_flags + compile_arch))
+env.Replace(CFLAGS    = os.getenv('CFLAGS',   ''))
+env.Replace(CXXFLAGS  = os.getenv('CXXFLAGS', ''))
+env.Replace(LINKFLAGS = os.getenv('LDFLAGS',  link_arch))
+env.Replace(LIBPATH   = [os.getenv('LIBPATH', '')])
 
 # Set -pthread flag explicitly to make sure that pthreads are
 # enabled on all platforms.
-env.Append(CPPFLAGS = ' -pthread')
+env.Append(CCFLAGS = ' -pthread')
 
 # Freebsd ports are installed under /usr/local
 if sysname == 'freebsd' or sysname == 'sunos':
@@ -195,8 +209,7 @@ env.Append(CPPFLAGS = ' -DHAVE_COMMON_H')
 
 # Common C/CXX flags
 # These should be kept minimal as they are appended after C/CXX specific flags
-env.Replace(CCFLAGS = opt_flags + compile_arch +
-                      ' -Wall -Wextra -Wno-unused-parameter')
+env.Append(CCFLAGS = ' -Wall -Wextra -Wno-unused-parameter')
 
 # C-specific flags
 env.Replace(CFLAGS = ' -std=c99 -fno-strict-aliasing -pipe')
@@ -210,10 +223,10 @@ if sysname != 'sunos':
 
 
 # Linker flags
-# TODO: enable '-Wl,--warn-common -Wl,--fatal-warnings' after warnings from
+# TODO: enable ' -Wl,--warn-common -Wl,--fatal-warnings' after warnings from
 # static linking have beed addressed
 #
-env.Append(LINKFLAGS = link_arch)
+#env.Append(LINKFLAGS = ' -Wl,--warn-common -Wl,--fatal-warnings')
 
 #
 # Check required headers and libraries (autoconf functionality)
@@ -393,14 +406,13 @@ conf.env['CPPPATH'] = cpppath_saved
 
 # these will be used only with our softaware
 if strict_build_flags == 1:
-    conf.env.Append(CPPFLAGS = ' -Werror')
-    conf.env.Append(CCFLAGS  = ' -pedantic')
+    conf.env.Append(CCFLAGS = ' -Werror -pedantic')
     if 'clang' not in conf.env['CXX']:
         conf.env.Append(CXXFLAGS = ' -Weffc++ -Wold-style-cast')
     else:
-        conf.env.Append(CPPFLAGS = ' -Wno-self-assign')
+        conf.env.Append(CCFLAGS = ' -Wno-self-assign')
         if 'ccache' in conf.env['CXX']:
-            conf.env.Append(CPPFLAGS = ' -Qunused-arguments')
+            conf.env.Append(CCFLAGS = ' -Qunused-arguments')
 
 env = conf.Finish()
 

--- a/chromium/aligned_memory.h
+++ b/chromium/aligned_memory.h
@@ -34,7 +34,6 @@
 #ifndef BASE_MEMORY_ALIGNED_MEMORY_H_
 #define BASE_MEMORY_ALIGNED_MEMORY_H_
 
-//#include "base/basictypes.h"
 #include "compile_assert.h"
 #include "compiler_specific.h"
 

--- a/chromium/build_config.h
+++ b/chromium/build_config.h
@@ -1,7 +1,6 @@
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 // This file adds defines about the platform we're currently building on.
 //  Operating System:
 //    OS_WIN / OS_MACOSX / OS_LINUX / OS_POSIX (MACOSX or LINUX)
@@ -10,72 +9,13 @@
 //  Processor:
 //    ARCH_CPU_X86 / ARCH_CPU_X86_64 / ARCH_CPU_X86_FAMILY (X86 or X86_64)
 //    ARCH_CPU_32_BITS / ARCH_CPU_64_BITS
-
 #ifndef BUILD_BUILD_CONFIG_H_
 #define BUILD_BUILD_CONFIG_H_
-
-#if defined(__APPLE__)
-#include <TargetConditionals.h>
-#endif
-
 // A set of macros to use for platform detection.
-#if defined(ANDROID)
-#define OS_ANDROID 1
-#elif defined(__APPLE__)
-#define OS_MACOSX 1
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#define OS_IOS 1
-#endif  // defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
-#elif defined(__native_client__)
+#if defined(__native_client__)
 #define OS_NACL 1
-#elif defined(__linux__)
-#define OS_LINUX 1
-// Use TOOLKIT_GTK on linux if TOOLKIT_VIEWS isn't defined.
-#if !defined(TOOLKIT_VIEWS) && defined(USE_X11)
-#define TOOLKIT_GTK
-#endif
-#elif defined(_WIN32)
-#define OS_WIN 1
-#define TOOLKIT_VIEWS 1
-#elif defined(__FreeBSD__)
-#define OS_FREEBSD 1
-#define TOOLKIT_GTK
-#elif defined(__OpenBSD__)
-#define OS_OPENBSD 1
-#define TOOLKIT_GTK
-#elif defined(__sun)
-#define OS_SOLARIS 1
-#define TOOLKIT_GTK
-#else
-#error Please add support for your platform in build/build_config.h
-#endif
-
-#if defined(USE_OPENSSL) && defined(USE_NSS)
-#error Cannot use both OpenSSL and NSS
-#endif
-
-// For access to standard BSD features, use OS_BSD instead of a
-// more specific macro.
-#if defined(OS_FREEBSD) || defined(OS_OPENBSD)
-#define OS_BSD 1
-#endif
-
-// For access to standard POSIXish features, use OS_POSIX instead of a
-// more specific macro.
-#if defined(OS_MACOSX) || defined(OS_LINUX) || defined(OS_FREEBSD) ||     \
-    defined(OS_OPENBSD) || defined(OS_SOLARIS) || defined(OS_ANDROID) ||  \
-    defined(OS_NACL)
-#define OS_POSIX 1
-#endif
-
-#if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_ANDROID) && \
-    !defined(OS_NACL) && !defined(USE_MESSAGEPUMP_LINUX)
-#define USE_X11 1  // Use X for graphics.
-#endif
-
-// Use tcmalloc
-#if (defined(OS_WIN) || defined(OS_LINUX)) && !defined(NO_TCMALLOC)
-#define USE_TCMALLOC 1
+#elif defined(__ANDROID__)
+#define OS_ANDROID 1
 #endif
 
 // Compiler detection.
@@ -91,83 +31,8 @@
 //   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
 //   http://www.agner.org/optimize/calling_conventions.pdf
 //   or with gcc, run: "echo | gcc -E -dM -"
-#if defined(_M_X64) || defined(__x86_64__)
+#if defined(_M_X64) || defined(__x86_64__) || defined(_M_IX86) || defined(__i386__)
 #define ARCH_CPU_X86_FAMILY 1
-#define ARCH_CPU_X86_64 1
-#define ARCH_CPU_64_BITS 1
-#define ARCH_CPU_LITTLE_ENDIAN 1
-#elif defined(_M_IX86) || defined(__i386__)
-#define ARCH_CPU_X86_FAMILY 1
-#define ARCH_CPU_X86 1
-#define ARCH_CPU_32_BITS 1
-#define ARCH_CPU_LITTLE_ENDIAN 1
-#elif defined(__ARMEL__)
-#define ARCH_CPU_ARM_FAMILY 1
-#define ARCH_CPU_ARMEL 1
-#define ARCH_CPU_32_BITS 1
-#define ARCH_CPU_LITTLE_ENDIAN 1
-#elif defined(__aarch64__)
-#define ARCH_CPU_ARM_FAMILY 1
-#define ARCH_CPU_ARMEL 1
-#define ARCH_CPU_64_BITS 1
-#define ARCH_CPU_LITTLE_ENDIAN 1
-#elif defined(__pnacl__)
-#define ARCH_CPU_32_BITS 1
-#elif defined(__MIPSEL__)
-#define ARCH_CPU_MIPS_FAMILY 1
-#define ARCH_CPU_MIPSEL 1
-#define ARCH_CPU_32_BITS 1
-#define ARCH_CPU_LITTLE_ENDIAN 1
-#elif defined(__PPC__)
-#if defined(__PPC64__)
-#define ARCH_CPU_64_BITS 1
-#else
-#define ARCH_CPU_32_BITS 1
-#endif
-#define ARCH_CPU_BIG_ENDIAN 1
-#elif defined(__s390__)
-#if defined(__s390x__)
-#define ARCH_CPU_64_BITS 1
-#else
-#define ARCH_CPU_32_BITS 1
-#endif
-#define ARCH_CPU_BIG_ENDIAN 1
-#else
-#error Please add support for your architecture in build/build_config.h
-#endif
-
-// Type detection for wchar_t.
-#if defined(OS_WIN)
-#define WCHAR_T_IS_UTF16
-#elif defined(OS_POSIX) && defined(COMPILER_GCC) && \
-    defined(__WCHAR_MAX__) && \
-    (__WCHAR_MAX__ == 0x7fffffff || __WCHAR_MAX__ == 0xffffffff)
-#define WCHAR_T_IS_UTF32
-#elif defined(OS_POSIX) && defined(COMPILER_GCC) && \
-    defined(__WCHAR_MAX__) && \
-    (__WCHAR_MAX__ == 0x7fff || __WCHAR_MAX__ == 0xffff)
-// On Posix, we'll detect short wchar_t, but projects aren't guaranteed to
-// compile in this mode (in particular, Chrome doesn't). This is intended for
-// other projects using base who manage their own dependencies and make sure
-// short wchar works for them.
-#define WCHAR_T_IS_UTF16
-#else
-#error Please add support for your compiler in build/build_config.h
-#endif
-
-#if defined(__ARMEL__) && !defined(OS_IOS)
-#define WCHAR_T_IS_UNSIGNED 1
-#elif defined(__MIPSEL__)
-#define WCHAR_T_IS_UNSIGNED 0
-#endif
-
-#if defined(OS_ANDROID)
-// The compiler thinks std::string::const_iterator and "const char*" are
-// equivalent types.
-#define STD_STRING_ITERATOR_IS_CHAR_POINTER
-// The compiler thinks base::string16::const_iterator and "char16*" are
-// equivalent types.
-#define BASE_STRING16_ITERATOR_IS_CHAR16_POINTER
 #endif
 
 #endif  // BUILD_BUILD_CONFIG_H_

--- a/galerautils/src/gu_mmap.cpp
+++ b/galerautils/src/gu_mmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2013 Codership Oy <info@codership.com>
+ * Copyright (C) 2009-2015 Codership Oy <info@codership.com>
  *
  * $Id$
  */
@@ -11,6 +11,10 @@
 
 #include <cerrno>
 #include <sys/mman.h>
+
+#ifndef MAP_NORESERVE
+#define MAP_NORESERVE 0
+#endif
 
 // to avoid -Wold-style-cast
 extern "C" { static const void* const GU_MAP_FAILED = MAP_FAILED; }
@@ -30,8 +34,7 @@ namespace gu
                                   << "' failed";
         }
 
-#if !defined(__sun__) && !defined(__APPLE__) && !defined(__FreeBSD__)
-        /* Solaris, Darwin, and FreeBSD do not have MADV_DONTFORK */
+#if defined(MADV_DONTFORK)
         if (posix_madvise (ptr, size, MADV_DONTFORK))
         {
             int const err(errno);

--- a/galerautils/src/gu_rand.c
+++ b/galerautils/src/gu_rand.c
@@ -1,4 +1,4 @@
-// Copyright (C) 2013 Codership Oy <info@codership.com>
+// Copyright (C) 2013-2015 Codership Oy <info@codership.com>
 
 /**
  * @file routines to generate "random" seeds for RNGs by collecting some easy
@@ -16,13 +16,14 @@
 
 /*! Structure to hold entropy data.
  *  Should be at least 20 bytes on 32-bit systems and 28 bytes on 64-bit */
+/*  Packed to avoid uninitialized data warnings when passed to hash */
 struct gu_rse
 {
     long long   time;
     const void* heap_ptr;
     const void* stack_ptr;
     long        pid;
-};
+}__attribute__((packed));
 
 typedef struct gu_rse gu_rse_t;
 


### PR DESCRIPTION
- SConstruct: removed -mtune=native by default since it is not supported on every platform
- galerautils/src/gu_rand.c: packed seed struct to avoid uninitialized data warning on some platforms
- chromium/build_config.h: made sure it defines only macros which are actually being used, which removes the need to define specific platforms
