### PR TITLE
refs codership/galera#367 use system ASIO if available

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -232,7 +232,34 @@ if sysname != 'sunos':
 # Check required headers and libraries (autoconf functionality)
 #
 
-conf = Configure(env)
+#
+# Custom tests:
+#
+
+def CheckSystemASIOVersion(context):
+    system_asio_test_source_file = """
+#include <asio.hpp>
+
+#if ASIO_VERSION < 101001
+#error "Included asio version is too old"
+#endif
+
+int main()
+{
+    return 0;
+}
+
+"""
+    context.Message('Checking ASIO version (> 1.10.1) ... ')
+    result = context.TryLink(system_asio_test_source_file, '.cpp')
+    context.Result(result)
+    return result
+
+
+#
+# Construct confuration context
+#
+conf = Configure(env, custom_tests = {'CheckSystemASIOVersion': CheckSystemASIOVersion})
 
 # System headers and libraries
 
@@ -379,14 +406,21 @@ else:
     print 'Not using boost'
 
 # asio
-cpppath_saved = conf.env.get('CPPPATH')
-
-conf.env.Append(CPPPATH = [ '#/asio' ])
-if conf.CheckCXXHeader('asio.hpp'):
-    conf.env.Append(CPPFLAGS = ' -DHAVE_ASIO_HPP')
+use_system_asio = False
+if conf.CheckCXXHeader('asio.hpp') and conf.CheckSystemASIOVersion():
+    use_system_asio = True
+    conf.env.Append(CPPFLAGS = ' -DHAVE_SYSTEM_ASIO -DHAVE_ASIO_HPP')
 else:
-    print 'asio headers not found or not usable'
-    Exit(1)
+    print "Falling back to bundled asio"
+
+if not use_system_asio:
+    # Fall back to embedded asio
+    conf.env.Append(CPPPATH = [ '#/asio' ])
+    if conf.CheckCXXHeader('asio.hpp'):
+        conf.env.Append(CPPFLAGS = ' -DHAVE_ASIO_HPP')
+    else:
+        print 'asio headers not found or not usable'
+        Exit(1)
 
 # asio/ssl
 if ssl == 1:
@@ -402,7 +436,7 @@ if ssl == 1:
         print 'ssl support required but openssl library not found'
         print 'compile with ssl=0 or check that openssl library is usable'
         Exit(1)
-conf.env['CPPPATH'] = cpppath_saved
+
 
 # these will be used only with our softaware
 if strict_build_flags == 1:

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ Build-Depends: check,
                libboost-dev (>= 1.41),
                libboost-program-options-dev (>= 1.41),
                libssl-dev,
-               scons (>= 2)
+               scons (>= 2),
+               libasio-dev
 Homepage: http://www.galeracluster.com/
 Vcs-Git: git://github.com/codership/galera.git
 Vcs-Browser: http://github.com/codership/galera.git

--- a/galera/src/SConscript
+++ b/galera/src/SConscript
@@ -6,7 +6,6 @@ libgaleraxx_env = env.Clone()
 # Include paths
 libgaleraxx_env.Append(CPPPATH = Split('''
                                           #
-                                          #/asio
                                           #/common
                                           #/galerautils/src
                                           #/gcache/src

--- a/galera/src/ist.cpp
+++ b/galera/src/ist.cpp
@@ -80,6 +80,7 @@ galera::ist::Receiver::Receiver(gu::Config&           conf,
                                 TrxHandle::SlavePool& sp,
                                 const char*           addr)
     :
+    recv_addr_    (),
     io_service_   (),
     acceptor_     (io_service_),
     ssl_ctx_      (io_service_, asio::ssl::context::sslv23),

--- a/galera/src/ist.hpp
+++ b/galera/src/ist.hpp
@@ -70,6 +70,10 @@ namespace galera
 
             private:
 
+                // Non-copyable
+                Consumer(const Consumer&);
+                Consumer& operator=(const Consumer&);
+
                 gu::Cond   cond_;
                 TrxHandle* trx_;
             };
@@ -95,7 +99,7 @@ namespace galera
                    gcache::GCache& gcache,
                    const std::string& peer,
                    int version);
-            ~Sender();
+            virtual ~Sender();
 
             void send(wsrep_seqno_t first, wsrep_seqno_t last);
 

--- a/galera/src/ist_proto.hpp
+++ b/galera/src/ist_proto.hpp
@@ -14,6 +14,18 @@
 #include "gu_vector.hpp"
 
 //
+// Message class must have non-virtual destructor until
+// support up to version 3 is removed as serialization/deserialization
+// depends on the size of the class.
+//
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic push
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+# pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
+//
 // Sender                            Receiver
 // connect()                 ----->  accept()
 //                          <-----   send_handshake()
@@ -61,6 +73,8 @@ namespace galera
                 ctrl_   (ctrl   ),
                 len_    (len    )
             { }
+
+            ~Message() { }
 
             int      version() const { return version_; }
             Type     type()    const { return type_   ; }
@@ -578,5 +592,12 @@ namespace galera
         };
     }
 }
+
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic pop
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#endif
+
 
 #endif // GALERA_IST_PROTO_HPP

--- a/galera/tests/SConscript
+++ b/galera/tests/SConscript
@@ -6,7 +6,6 @@ env = check_env.Clone()
 # Include paths
 env.Append(CPPPATH = Split('''
                               #
-                              #/asio
                               #/common
                               #/galerautils/src
                               #/gcache/src

--- a/galerautils/src/SConscript
+++ b/galerautils/src/SConscript
@@ -67,7 +67,6 @@ libgalerautilsxx_env = env.Clone()
 # Include paths
 libgalerautilsxx_env.Append(CPPPATH = Split('''
                                                #
-                                               #/asio
                                                #/common
                                             '''))
 

--- a/galerautils/src/gu_asio.cpp
+++ b/galerautils/src/gu_asio.cpp
@@ -5,6 +5,7 @@
 #include "gu_config.hpp"
 #include "gu_asio.hpp"
 
+#include <boost/bind.hpp>
 
 void gu::ssl_register_params(gu::Config& conf)
 {

--- a/galerautils/src/gu_asio.hpp
+++ b/galerautils/src/gu_asio.hpp
@@ -13,8 +13,18 @@
 #include "gu_macros.h" // gu_likely()
 #include "common.h"    //
 
-#pragma GCC diagnostic ignored "-Weffc++"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
+#ifndef HAVE_SYSTEM_ASIO
+// Using embedded copy of ASIO requires turning off some
+// compiler warnings.
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic push
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+# pragma GCC diagnostic ignored "-Weffc++"
+# pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+#endif // ! HAVE_SYSTEM_ASIO
+
 #include "asio.hpp"
 #include "asio/ssl.hpp"
 
@@ -157,5 +167,12 @@ namespace gu
     }
 }
 
+#ifndef HAVE_SYSTEM_ASIO
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic pop
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#endif
+#endif // ! HAVE_SYSTEM_ASIO
 
 #endif // GU_ASIO_HPP

--- a/galerautils/tests/SConscript
+++ b/galerautils/tests/SConscript
@@ -6,7 +6,6 @@ env = check_env.Clone()
 # Include paths
 env.Append(CPPPATH = Split('''
                               #
-                              #/asio
                               #/galerautils/src
                            '''))
 

--- a/garb/SConscript
+++ b/garb/SConscript
@@ -7,7 +7,6 @@ garb_env = env.Clone()
 # Include paths
 garb_env.Append(CPPPATH = Split('''
                                    #
-                                   #/asio
                                    #/common
                                    #/galerautils/src
                                    #/gcs/src

--- a/gcomm/src/SConscript
+++ b/gcomm/src/SConscript
@@ -7,7 +7,6 @@ libgcomm_env = env.Clone()
 # Include paths
 libgcomm_env.Append(CPPPATH = Split('''
                                        #
-                                       #/asio
                                        #/common
                                        #/galerautils/src
                                        #/gcomm/src

--- a/gcomm/src/asio_tcp.hpp
+++ b/gcomm/src/asio_tcp.hpp
@@ -14,6 +14,17 @@
 #include <vector>
 #include <deque>
 
+//
+// Boost enable_shared_from_this<> does not have virtual destructor,
+// therefore need to ignore -Weffc++
+//
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic push
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+# pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
 namespace gcomm
 {
     class AsioTcpSocket;
@@ -107,5 +118,11 @@ private:
     asio::ip::tcp::acceptor acceptor_;
     SocketPtr accepted_socket_;
 };
+
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic pop
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#endif
 
 #endif // GCOMM_ASIO_TCP_HPP

--- a/gcomm/src/asio_udp.hpp
+++ b/gcomm/src/asio_udp.hpp
@@ -10,6 +10,17 @@
 #include <boost/enable_shared_from_this.hpp>
 #include <vector>
 
+//
+// Boost enable_shared_from_this<> does not have virtual destructor,
+// therefore need to ignore -Weffc++
+//
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic push
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+# pragma GCC diagnostic ignored "-Weffc++"
+#endif
+
 namespace gcomm
 {
     class AsioUdpSocket;
@@ -42,5 +53,11 @@ private:
     asio::ip::udp::endpoint  source_ep_;
     std::vector<gu::byte_t>  recv_buf_;
 };
+
+#if defined(__GNUG__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic pop
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#endif
 
 #endif // GCOMM_ASIO_UDP_HPP

--- a/gcomm/test/SConscript
+++ b/gcomm/test/SConscript
@@ -5,7 +5,6 @@ env = check_env.Clone()
 
 # Include paths
 env.Append(CPPPATH = Split('''
-                              #/asio
                               #/common
                               #/galerautils/src
                               #/gcomm/src


### PR DESCRIPTION
Made debian build to depend on libasio-dev and enhanced SConstruct
to check if system provides ASIO devel library and if it is recent
enough (> 1.10.1).

If ASIO devel library is not installed or is not recent enough,
build falls back to use of embedded copy.

Also reduced the scope of compiler warning suppressions when
system ASIO is used and fixed compiler warnings.
