### PR TITLE
use minherit(INHERIT_NONE) on FreeBSD to speed up process spawning for Galera SST

### DIFF
--- a/galerautils/src/gu_mmap.cpp
+++ b/galerautils/src/gu_mmap.cpp
@@ -41,6 +41,13 @@ namespace gu
             log_warn << "Failed to set MADV_DONTFORK on " << fd.name()
                      << ": " << err << " (" << strerror(err) << ")";
         }
+#elif defined(__FreeBSD__)
+		if (minherit (ptr, size, INHERIT_NONE))
+		{
+			int const err(errno);
+			log_warn << "Failed to set INHERIT_NONE on " << fd.name()
+			<< ": " << err << " (" << strerror(err) << ")";
+		}
 #endif
 
         /* benefits are questionable */


### PR DESCRIPTION
On Linux, the gucache is marked as MADV_DONTFORK to speed up Galera's usage of fork(). On FreeBSD, MADV_DONTFORK doesn't exists, so we should use the equivalent minherit(ptr, size, INHERIT_NONE).

This fixes an issue on FreeBSD where forking() for SST by a donor can take a long time (up to 30s) and stop the donor from responding to keepalives with a sufficiently gucache size. The cluster could get partitioned and stop responding while the IST was running or the IST could fail. By ensuring that the buffer pools are not forked() along, fork() is no longer slow and the donor stays reachable.

A similar pull request has been sent to percona/percona-xtradb-cluster, for the bufferpool, which is marked as MADV_DONTFORK on Linux as well.
