### PR TITLE
Display an error on missing SSL parameters

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,5 +26,6 @@ Authors from Codership Oy:
 Other contributors:
 
  * Stefan Langenmaier <stefan.langenmaier@gmail.com>
+ * Andrzej Godziuk <gdr@gdr.name>
  [add name and email/username above this line, but leave this line intact]
 

--- a/galerautils/src/gu_asio.cpp
+++ b/galerautils/src/gu_asio.cpp
@@ -150,4 +150,9 @@ void gu::ssl_prepare_context(const gu::Config& conf, asio::ssl::context& ctx,
                                << "' for SSL parameter '" << param
                                << "': " << extra_error_info(ec.code());
     }
+    catch (gu::NotSet& ec)
+    {
+        gu_throw_error(EINVAL) << "Missing required value for SSL parameter '"
+                               << param << "'";
+    }
 }


### PR DESCRIPTION
Currently when missing an SSL parameter, the behavior is to print:

```
Exception in creating receive loop.
```

which is not very helpful.

More: issue #399 
