### PR TITLE
clang-3.8.0 compile fix

### DIFF
--- a/galera/src/trx_handle.hpp
+++ b/galera/src/trx_handle.hpp
@@ -541,7 +541,11 @@ namespace galera
             assert(wso_);
             return *reinterpret_cast<WriteSetOut*>(this + 1);
         }
-        const WriteSetOut& write_set_out() const { return write_set_out(); }
+
+        const WriteSetOut& write_set_out() const
+        {
+            return const_cast<TrxHandle*>(this)->write_set_out();
+        }
 
         const WriteSetIn&  write_set_in () const { return write_set_in_;  }
 


### PR DESCRIPTION
Const cast this to ensure non-recursive call and thus prevent
compile error.

closes #412
