### PR TITLE
check memory alignment for write set out object

### DIFF
--- a/galera/src/trx_handle.hpp
+++ b/galera/src/trx_handle.hpp
@@ -539,6 +539,16 @@ namespace galera
              * I'll be damned if this+1 is not sufficiently well aligned. */
             assert(new_version());
             assert(wso_);
+            
+            /* Check for memory alignment, if it is not aligned, adjust it
+            */
+             uintptr_t alignment = reinterpret_cast<uintptr_t>(this + 1); 
+	         if(alignment % 8uL) { 
+	            std::cout << "Fixing misalignment\n";
+	
+	            alignment += 8uL - alignment % 8uL;	     
+	    }
+
             return *reinterpret_cast<WriteSetOut*>(this + 1);
         }
         const WriteSetOut& write_set_out() const


### PR DESCRIPTION
Hi, we have noticed in the galera trx_handle.hpp code, there is a function write_set_out() that returns the address after the trx_handle object without checking if the address is memory aligned. This address is subsequently used in a placement new expression in the method init_write_set_out().

We have tested in a much smaller program that the system will pad objects to 4 bytes, however, if the system’s word size is 8, that could potentially render the this+1 address memory misaligned. Even though we have not observed any memory misalignment in the actual galera code, this discovery motivate us to add guarding code for the memory allocation. Because according to the following doc, there is no good mechanism in compiler to make sure this address is aligned, and it can have unexpected results. The pull request will check for alignment and adjust it if it is not aligned,  please let us know what do you think, thanks. 

memory alignment: https://isocpp.org/wiki/faq/dtors#placement-new