### PR TITLE
Ensure clean abort when core piping is used

### DIFF
--- a/galerautils/src/gu_abort.c
+++ b/galerautils/src/gu_abort.c
@@ -19,7 +19,7 @@ void
 gu_abort (void)
 {
     /* avoid coredump */
-    struct rlimit core_limits = { 0, 0 };
+    struct rlimit core_limits = { 1, 1 };
     setrlimit (RLIMIT_CORE, &core_limits);
 
     /* restore default SIGABRT handler */


### PR DESCRIPTION
The Linux kernel treats the zero core file size limits differently
when the core dump is piped to a program. As a result of that, core
dump is generated in such cases.
By setting those limits to 1 the core dump generation can be avoided.

Signed-off-by: Gabor Orosz <goro@goro.hu>