### PR TITLE
Add fallthrough comments to correct gcc-7 compile

### DIFF
--- a/galera/src/key_set.hpp
+++ b/galera/src/key_set.hpp
@@ -173,6 +173,7 @@ public:
 #else
                 ret = (lhs[2] == rhs[2] && lhs[3] == rhs[3]);
 #endif /* WORDSIZE */
+                /* fallthrough */
             case FLAT8:
             case FLAT8A:
                 /* shift is to clear up the header */

--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -276,7 +276,7 @@ galera::ReplicatorSMM::~ReplicatorSMM()
     case S_JOINED:
     case S_SYNCED:
     case S_DONOR:
-        close();
+        close(); // fallthrough
     case S_CLOSING:
         // @todo wait that all users have left the building
     case S_CLOSED:
@@ -857,8 +857,8 @@ wsrep_status_t galera::ReplicatorSMM::replay_trx(TrxHandle* trx, void* trx_ctx)
         ApplyOrder ao(*trx);
         gu_trace(apply_monitor_.enter(ao));
         trx->set_state(TrxHandle::S_MUST_REPLAY_CM);
-        // fall through
     }
+        // fall through
     case TrxHandle::S_MUST_REPLAY_CM:
         if (co_mode_ != CommitOrder::BYPASS)
         {

--- a/galerautils/src/gu_dbug.c
+++ b/galerautils/src/gu_dbug.c
@@ -705,7 +705,7 @@ _gu_db_push_(const char *control)
 	    break;
 	case 'A':
 	case 'O':
-	    _gu_db_stack->flags |= FLUSH_ON_WRITE;
+	    _gu_db_stack->flags |= FLUSH_ON_WRITE; /* fallthrough */
 	case 'a':
 	case 'o':
 	    if (*scan++ == ',') {

--- a/galerautils/src/gu_mmh3.h
+++ b/galerautils/src/gu_mmh3.h
@@ -184,24 +184,24 @@ _mmh3_128_tail (const uint8_t* const tail, size_t const len,
 
     switch(len & 15)
     {
-    case 15: k2 ^= ((uint64_t)tail[14]) << 48;
-    case 14: k2 ^= ((uint64_t)tail[13]) << 40;
-    case 13: k2 ^= ((uint64_t)tail[12]) << 32;
-    case 12: k2 ^= ((uint64_t)tail[11]) << 24;
-    case 11: k2 ^= ((uint64_t)tail[10]) << 16;
-    case 10: k2 ^= ((uint64_t)tail[ 9]) << 8;
+    case 15: k2 ^= ((uint64_t)tail[14]) << 48; // fallthrough
+    case 14: k2 ^= ((uint64_t)tail[13]) << 40; // fallthrough
+    case 13: k2 ^= ((uint64_t)tail[12]) << 32; // fallthrough
+    case 12: k2 ^= ((uint64_t)tail[11]) << 24; // fallthrough
+    case 11: k2 ^= ((uint64_t)tail[10]) << 16; // fallthrough
+    case 10: k2 ^= ((uint64_t)tail[ 9]) << 8; // fallthrough
     case  9: k2 ^= ((uint64_t)tail[ 8]) << 0;
         k2 *= _mmh3_128_c2; k2 = GU_ROTL64(k2,33); k2 *= _mmh3_128_c1; h2 ^= k2;
         k1 = gu_le64(((uint64_t*)tail)[0]);
         k1 *= _mmh3_128_c1; k1 = GU_ROTL64(k1,31); k1 *= _mmh3_128_c2; h1 ^= k1;
         break;
-    case  8: k1 ^= ((uint64_t)tail[ 7]) << 56;
-    case  7: k1 ^= ((uint64_t)tail[ 6]) << 48;
-    case  6: k1 ^= ((uint64_t)tail[ 5]) << 40;
-    case  5: k1 ^= ((uint64_t)tail[ 4]) << 32;
-    case  4: k1 ^= ((uint64_t)tail[ 3]) << 24;
-    case  3: k1 ^= ((uint64_t)tail[ 2]) << 16;
-    case  2: k1 ^= ((uint64_t)tail[ 1]) << 8;
+    case  8: k1 ^= ((uint64_t)tail[ 7]) << 56; // fallthrough
+    case  7: k1 ^= ((uint64_t)tail[ 6]) << 48; // fallthrough
+    case  6: k1 ^= ((uint64_t)tail[ 5]) << 40; // fallthrough
+    case  5: k1 ^= ((uint64_t)tail[ 4]) << 32; // fallthrough
+    case  4: k1 ^= ((uint64_t)tail[ 3]) << 24; // fallthrough
+    case  3: k1 ^= ((uint64_t)tail[ 2]) << 16; // fallthrough
+    case  2: k1 ^= ((uint64_t)tail[ 1]) << 8; // fallthrough
     case  1: k1 ^= ((uint64_t)tail[ 0]) << 0;
         k1 *= _mmh3_128_c1; k1 = GU_ROTL64(k1,31); k1 *= _mmh3_128_c2; h1 ^= k1;
     };

--- a/galerautils/src/gu_spooky.h
+++ b/galerautils/src/gu_spooky.h
@@ -244,37 +244,37 @@ static GU_INLINE void gu_spooky_short_host(
     switch (remainder)
     {
     case 15:
-        d += ((uint64_t)u.p8[14]) << 48;
+        d += ((uint64_t)u.p8[14]) << 48; // fallthrough
     case 14:
-        d += ((uint64_t)u.p8[13]) << 40;
+        d += ((uint64_t)u.p8[13]) << 40; // fallthrough
     case 13:
-        d += ((uint64_t)u.p8[12]) << 32;
+        d += ((uint64_t)u.p8[12]) << 32; // fallthrough
     case 12:
         d += gu_le32(u.p32[2]);
         c += gu_le64(u.p64[0]);
         break;
     case 11:
-        d += ((uint64_t)u.p8[10]) << 16;
+        d += ((uint64_t)u.p8[10]) << 16; // fallthrough
     case 10:
-        d += ((uint64_t)u.p8[9]) << 8;
+        d += ((uint64_t)u.p8[9]) << 8; // fallthrough
     case 9:
-        d += (uint64_t)u.p8[8];
+        d += (uint64_t)u.p8[8]; // fallthrough
     case 8:
         c += gu_le64(u.p64[0]);
         break;
     case 7:
-        c += ((uint64_t)u.p8[6]) << 48;
+        c += ((uint64_t)u.p8[6]) << 48; // fallthrough
     case 6:
-        c += ((uint64_t)u.p8[5]) << 40;
+        c += ((uint64_t)u.p8[5]) << 40; // fallthrough
     case 5:
-        c += ((uint64_t)u.p8[4]) << 32;
+        c += ((uint64_t)u.p8[4]) << 32; // fallthrough
     case 4:
         c += gu_le32(u.p32[0]);
         break;
     case 3:
-        c += ((uint64_t)u.p8[2]) << 16;
+        c += ((uint64_t)u.p8[2]) << 16; // fallthrough
     case 2:
-        c += ((uint64_t)u.p8[1]) << 8;
+        c += ((uint64_t)u.p8[1]) << 8; // fallthrough
     case 1:
         c += (uint64_t)u.p8[0];
         break;

--- a/galerautils/src/gu_utils.c
+++ b/galerautils/src/gu_utils.c
@@ -27,13 +27,13 @@ gu_str2ll (const char* str, long long* ll)
     {
     case 't':
     case 'T':
-        shift += 10;
+        shift += 10; // fallthrough
     case 'g':
     case 'G':
-        shift += 10;
+        shift += 10; // fallthrough
     case 'm':
     case 'M':
-        shift += 10;
+        shift += 10; // fallthrough
     case 'k':
     case 'K':
         shift += 10;
@@ -47,6 +47,7 @@ gu_str2ll (const char* str, long long* ll)
             else llret = LLONG_MIN;
             errno = ERANGE;
         }
+        // fallthrough
     default:
         *ll = llret;
     }

--- a/gcomm/src/evs_proto.cpp
+++ b/gcomm/src/evs_proto.cpp
@@ -2629,8 +2629,8 @@ int gcomm::evs::Proto::handle_down(Datagram& wb, const ProtoDownMeta& dm)
         case EAGAIN:
         {
             output_.push_back(std::make_pair(wb, dm));
-            // Fall through
         }
+            // Fall through
         case 0:
             ret = 0;
             break;

--- a/gcs/src/gcs.cpp
+++ b/gcs/src/gcs.cpp
@@ -831,6 +831,7 @@ _join (gcs_conn_t* conn, gcs_seqno_t seqno)
     case -ENOTCONN:
         gu_warn ("Sending JOIN failed: %d (%s). "
                  "Will retry in new primary component.", err, strerror(-err));
+        // fallthrough
     case 0:
         return 0;
     default:

--- a/gcs/src/gcs_core.cpp
+++ b/gcs/src/gcs_core.cpp
@@ -812,6 +812,7 @@ core_handle_comp_msg (gcs_core_t*          core,
                   "WAIT_STATE_MSG. Can't continue.");
         ret = -ENOTRECOVERABLE;
         assert(0);
+        break;
     default:
         gu_fatal ("Failed to handle component message: %d (%s)!",
                   ret, strerror (-ret));

--- a/gcs/src/gcs_test.cpp
+++ b/gcs/src/gcs_test.cpp
@@ -644,15 +644,19 @@ static long gcs_test_conf (gcs_test_conf_t *conf, long argc, char *argv[])
     case 6:
         conf->n_recv = strtol (argv[5], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fallthrough
     case 5:
         conf->n_send = strtol (argv[4], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fallthrough
     case 4:
         conf->n_repl = strtol (argv[3], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fallthrough
     case 3:
         conf->n_tries = strtol (argv[2], &endptr, 10);
         if ('\0' != *endptr) goto error;
+        // fallthrough
     case 2:
         conf->backend = argv[1];
         break;

--- a/www.evanjones.ca/crc32c.c
+++ b/www.evanjones.ca/crc32c.c
@@ -714,7 +714,7 @@ uint32_t crc32cHardware32(uint32_t crc, const void* data, size_t length) {
     */
     switch (length) {
         case 3:
-            crc = __builtin_ia32_crc32qi(crc, *p_buf++);
+            crc = __builtin_ia32_crc32qi(crc, *p_buf++); // fallthrough
         case 2:
             crc = __builtin_ia32_crc32hi(crc, *(uint16_t*) p_buf);
             break;
@@ -755,22 +755,23 @@ uint32_t crc32cHardware64(uint32_t crc, const void* data, size_t length) {
     */
     switch (length) {
         case 7:
-            crc32bit = __builtin_ia32_crc32qi(crc32bit, *p_buf++);
+            crc32bit = __builtin_ia32_crc32qi(crc32bit, *p_buf++); // fallthrough
         case 6:
             crc32bit = __builtin_ia32_crc32hi(crc32bit, *(uint16_t*) p_buf);
             p_buf += 2;
         // case 5 is below: 4 + 1
+        // fallthrough
         case 4:
             crc32bit = __builtin_ia32_crc32si(crc32bit, *(uint32_t*) p_buf);
             break;
         case 3:
-            crc32bit = __builtin_ia32_crc32qi(crc32bit, *p_buf++);
+            crc32bit = __builtin_ia32_crc32qi(crc32bit, *p_buf++); // fallthrough
         case 2:
             crc32bit = __builtin_ia32_crc32hi(crc32bit, *(uint16_t*) p_buf);
             break;
         case 5:
             crc32bit = __builtin_ia32_crc32si(crc32bit, *(uint32_t*) p_buf);
-            p_buf += 4;
+            p_buf += 4; // fallthrough
         case 1:
             crc32bit = __builtin_ia32_crc32qi(crc32bit, *p_buf);
             break;


### PR DESCRIPTION
Caused by -Werror=implicit-fallthrough

closes #459 

$CXX  --version
g++ (GCC) 7.1.1 20170504

From #464, #465 I couldn't work out if these two remaining issues where intended or accidental fall throughs.