### PR TITLE
Minor spelling error in error message

### DIFF
--- a/galera/src/replicator_smm.cpp
+++ b/galera/src/replicator_smm.cpp
@@ -1247,7 +1247,7 @@ void galera::ReplicatorSMM::process_trx(void* recv_ctx, TrxHandle* trx)
 
             log_fatal << "Failed to apply trx: " << *trx;
             log_fatal << e.what();
-            log_fatal << "Node consistency compromized, aborting...";
+            log_fatal << "Node consistency compromised, aborting...";
             abort();
         }
         break;


### PR DESCRIPTION
When you get this error, it is very confusing if you're trying to Google it. Using the correct spelling might help ;-)