### PR TITLE
Galera SST scripts shouldn't access grastate.dat

### DIFF
--- a/galera/src/saved_state.cpp
+++ b/galera/src/saved_state.cpp
@@ -12,6 +12,12 @@
 #include <sys/file.h>
 #include <fcntl.h>
 
+#ifdef __GLIBC__
+#define STR_O_EXCL_CLOEXEC "ex"
+#else
+#define STR_O_EXCL_CLOEXEC ""
+#endif
+
 namespace galera
 {
 
@@ -44,7 +50,7 @@ SavedState::SavedState  (const std::string& file) :
         log_warn << "Could not open state file for reading: '" << file << '\'';
     }
 
-    fs_ = fopen(file.c_str(), "a");
+    fs_ = fopen(file.c_str(), "a" STR_O_EXCL_CLOEXEC);
 
     if (!fs_)
     {


### PR DESCRIPTION
When SST scripts they inherit the open file descriptors.

Here we use the GLIBC extensions to fopen, 'e', to ensure
that forked processes don't inherit the file descriptor, and 'x'
which ensure exclusive access.

closes #339