### PR TITLE
Refs codership/galera#534 Unescape IPv6 bind_ip when joining the cluster

### DIFF
--- a/gcomm/src/asio_tcp.cpp
+++ b/gcomm/src/asio_tcp.cpp
@@ -180,7 +180,7 @@ void gcomm::AsioTcpSocket::connect(const gu::URI& uri)
             if (!bind_ip.empty()) {
                 socket_.open(i->endpoint().protocol());
                 asio::ip::tcp::endpoint ep(
-                    asio::ip::address::from_string(bind_ip),
+                    asio::ip::address::from_string(gu::unescape_addr(bind_ip)),
                     // connect from any port.
                     0);
                 socket_.bind(ep);


### PR DESCRIPTION
When IPv6 is used in option gmcast.listen_addr, it must be enclosed
in square brackets. This option is also used as the source address to
bind to before connecting to the cluster.

The source address cannot be bound to an IPv6 address when it contains
square brackets, so make sure we removed them when needed.