### PR TITLE
Set base_dir by default as /var/lib/galera instead of / (Closes: #313)

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -12,7 +12,7 @@
 #define COMMON_BASE_PORT_DEFAULT "4567"
 
 #define COMMON_BASE_DIR_KEY      "base_dir"
-#define COMMON_BASE_DIR_DEFAULT  "."
+#define COMMON_BASE_DIR_DEFAULT  "/var/lib/galera"
 
 #define COMMON_STATE_FILE "grastate.dat"
 #define COMMON_VIEW_STAT_FILE "gvwstate.dat"


### PR DESCRIPTION
The old default value '.' often translate simply to system root '/' when
garbd (most often) is run from a system init/service file that has no
path or is just '/' to begin with. This is a bad default, garbd should not
imply that it wants to write to file system root.

Many users seem to set this manually to /var/lib/galera or /var/lib/garb.
On Debian/Ubuntu systems I've seen users set in /etc/default/garbd:
  GALERA_OPTIONS="base_dir=/var/lib/galera/"

This change in the global default will render such hacks unnecessary.