### PR TITLE
Handle corrupt buffer size during GCache recovery

### DIFF
--- a/gcache/src/gcache_rb_store.cpp
+++ b/gcache/src/gcache_rb_store.cpp
@@ -1072,6 +1072,11 @@ namespace gcache
                     }
 
                     bh = BH_next(bh);
+
+                    // A corrupt buffer segment size could lead out of the ring
+                    if (gu_unlikely(reinterpret_cast<uint8_t*>(bh) > end_)) {
+                        goto full_reset;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
4bb58377cf3ee02e4c69ce329c2e099b07c79368 did not solve the whole GCache recovery from a corrupted `galera.cache` file use-case, as the scan for discarding locked-in buffers part could experience the same issue, when the size is incorrect in the given buffer header.