### PR TITLE
4.x configurable paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,14 +107,19 @@ add_subdirectory(galera)
 add_subdirectory(scripts/packages)
 add_subdirectory(wsrep/tests)
 
+# Make the install destination for documentation files configurable
+if(NOT DEFINED INSTALL_DOCDIR)
+  set(INSTALL_DOCDIR "doc" CACHE STRING "path to install documentation to")
+endif()
+
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
   install(FILES
     ${PROJECT_SOURCE_DIR}/AUTHORS
     ${PROJECT_SOURCE_DIR}/COPYING
     ${PROJECT_SOURCE_DIR}/README
-    DESTINATION doc)
+    DESTINATION ${INSTALL_DOCDIR} )
   install(FILES ${PROJECT_SOURCE_DIR}/asio/LICENSE_1_0.txt
-    DESTINATION doc
+    DESTINATION ${INSTALL_DOCDIR}
     RENAME LICENSE.asio)
 endif()
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,4 +30,5 @@ Other contributors:
  * Christian Hesse <mail@eworm.de>
  * Andrzej Godziuk <gdr@gdr.name>
  * Otto Kekäläinen <otto@kekalainen.net>
+ * Michal Schorm <mschorm@centrum.cz>
  [add name and email/username above this line, but leave this line intact]

--- a/galera/src/CMakeLists.txt
+++ b/galera/src/CMakeLists.txt
@@ -112,7 +112,12 @@ endif()
 
 target_link_libraries(galera_smm galera ${GALERA_LINK_OPTIONS})
 
-install(TARGETS galera_smm DESTINATION lib)
+# Make the install destination for the shared library configurable
+if(NOT DEFINED INSTALL_LIBDIR)
+  set(INSTALL_LIBDIR "lib" CACHE STRING "path to install shared libraries to")
+endif()
+
+install(TARGETS galera_smm DESTINATION ${INSTALL_LIBDIR})
 
 # The following checks are guaranteed to work only
 # Linux platform, we skip them on others.

--- a/garb/CMakeLists.txt
+++ b/garb/CMakeLists.txt
@@ -31,14 +31,51 @@ target_compile_options(garbd
 target_link_libraries(garbd gcs4garb gcomm gcache
   ${Boost_PROGRAM_OPTIONS_LIBRARIES})
 
-install(TARGETS garbd DESTINATION bin)
+# Make the install destination for garbd binary configurable
+if(NOT DEFINED INSTALL_GARBD)
+  set(INSTALL_GARBD "bin" CACHE STRING "path to install garbd binary to")
+endif()
+
+install(TARGETS garbd
+  DESTINATION ${INSTALL_GARBD})
+
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
+
+  # Make the install destination for garbd-systemd wrapper script configurable
+  if(NOT DEFINED INSTALL_GARBD-SYSTEMD)
+    set(INSTALL_GARBD-SYSTEMD "share" CACHE STRING "path to install garbd-systemd wrapper script to")
+  endif()
+
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/files/garb-systemd
+    DESTINATION ${INSTALL_GARBD-SYSTEMD})
+
+  # Make the install destination for garbd configuration file configurable
+  if(NOT DEFINED INSTALL_CONFIGURATION)
+    set(INSTALL_CONFIGURATION "share" CACHE STRING "path to install garbd configuration to")
+  endif()
+
   install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/files/garb.cnf
+    DESTINATION ${INSTALL_CONFIGURATION}
+    RENAME garb)
+
+  # Make the install destination for garbd systemd service file configurable
+  if(NOT DEFINED INSTALL_SYSTEMD_SERVICE)
+    set(INSTALL_SYSTEMD_SERVICE "share" CACHE STRING "path to install garbd Systemd service to")
+  endif()
+
+  install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/files/garb.service
-    ${CMAKE_CURRENT_SOURCE_DIR}/files/garb-systemd
-    DESTINATION share)
+    DESTINATION ${INSTALL_SYSTEMD_SERVICE})
+
+  # Make the install destination for manpage configurable
+  if(NOT DEFINED INSTALL_MANPAGE)
+    set(INSTALL_MANPAGE "man/man8" CACHE STRING "path to install manpage to")
+  endif()
+
   install(FILES
     ${PROJECT_SOURCE_DIR}/man/garbd.8
-    DESTINATION man/man8)
+    DESTINATION ${INSTALL_MANPAGE})
+
 endif()


### PR DESCRIPTION
In Fedora, RHEL and CentOS, we use different paths for the resulting files.
The compromise I bring is to make all the needed paths configurable, while defaulting to the values that are used until now.