### PR TITLE
remove duplicate va_end call

### DIFF
--- a/galerautils/src/gu_dbug.c
+++ b/galerautils/src/gu_dbug.c
@@ -1040,7 +1040,6 @@ _gu_db_doprnt_(const char *format, ...)
 	}
 	(void) fprintf(_gu_db_fp_, "%s: ", state->u_keyword);
 	(void) vfprintf(_gu_db_fp_, format, args);
-	va_end(args);
 	(void) fputc('\n', _gu_db_fp_);
 	dbug_flush(state);
 	errno = save_errno;


### PR DESCRIPTION
From `man va_end`:
```
va_end()
  Each  invocation  of  va_start()  must  be  matched  by a corresponding invocation of
  va_end() in the same function.  After the call va_end(ap) the variable  ap  is  unde‐
  fined.   Multiple  traversals  of the list, each bracketed by va_start() and va_end()
  are possible.  va_end() may be a macro or a function.
```
In the `_gu_db_doprnt_` function the `va_end` is called on the already undefined `args` variable, which can cause undefined behavior. This PR proposes to remove one `va_end(args)` call.
