### PR TITLE
Update garb_config.cpp

### DIFF
--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -143,7 +143,7 @@ Config::Config (int argc, char* argv[])
     strip_quotes(cfg_);
 
     if (options_.length() > 0) options_ += "; ";
-    options_ += "gcs.fc_limit=9999999; gcs.fc_factor=1.0; gcs.fc_single_primary=yes";
+    options_ += "gcs.fc_limit=9999999; gcs.fc_factor=1.0; gcs.fc_single_primary=yes;";
     if (!workdir_.empty())
     {
         options_ += " base_dir=" + workdir_ + ";";


### PR DESCRIPTION
Added semicolon to line 146 to fix "More than one value for key 'gcs.fc_singele_primary' at 'gcs.fc_single_primary=yes base_dir=...' in parameter list." error.