### PR TITLE
4.x ret error

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -313,7 +313,6 @@ build_packages()
     else # build RPM
         ./rpm.sh $GALERA_VER
     fi
-    local RET=$?
 
     set -e
 


### PR DESCRIPTION
Per https://buildbot.mariadb.org/#/builders/325/builds/844 we see that RET=2 per the test failure, but incorrectly gets reassigned to 0