### PR TITLE
Enhance packaging of the documentation files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,9 +111,8 @@ add_subdirectory(wsrep/tests)
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
   install(FILES
-    ${PROJECT_SOURCE_DIR}/AUTHORS
     ${PROJECT_SOURCE_DIR}/COPYING
-    ${PROJECT_SOURCE_DIR}/README
+    ${PROJECT_SOURCE_DIR}/scripts/packages/README-MySQL
     DESTINATION doc)
   install(FILES ${PROJECT_SOURCE_DIR}/asio/LICENSE_1_0.txt
     DESTINATION doc


### PR DESCRIPTION
--

This commit aims to upstream patch used in Fedora Linux:
  https://src.fedoraproject.org/rpms/galera/blob/152e656/f/docs.patch

--

AUTHORS file contains single line, and upstreampackaged does not pack it. For those reasons I don't find it useful to pack it either.

The README file contains infromation on how to build the project from sources, and thus isn't useful for the end users.

On the other hand, the README-MySQL isn't prepared for packing by CMake, but it contains useful information about the software usage and it is package in upstream-produced packages. So I'd pack this one instead of the above two.