### PR TITLE
Add missing semicolon to fix garbd's -w/WORK_DIR parameter

### DIFF
--- a/garb/garb_config.cpp
+++ b/garb/garb_config.cpp
@@ -143,7 +143,7 @@ Config::Config (int argc, char* argv[])
     strip_quotes(cfg_);
 
     if (options_.length() > 0) options_ += "; ";
-    options_ += "gcs.fc_limit=9999999; gcs.fc_factor=1.0; gcs.fc_single_primary=yes";
+    options_ += "gcs.fc_limit=9999999; gcs.fc_factor=1.0; gcs.fc_single_primary=yes;";
     if (!workdir_.empty())
     {
         options_ += " base_dir=" + workdir_ + ";";


### PR DESCRIPTION
As a result of merging b3c4983 and 29d906e the mandatory semicolon was lost, causing syntax error:

    FATAL: Exception in creating receive loop: More than one value for key
    'gcs.fc_single_primary' at ' gcs.fc_single_primary=yes base_dir=/tmp'
    in parameter list.

As a result also the -w parameter (typically enabled from /etc/default/garb with the WORK_DIR= variable) failed to work.

Closes: #672

This fix has been in [Debian](https://tracker.debian.org/pkg/galera-4) for a long time already without anyone reporting regressions.