### PR TITLE
Declare cmake 4.0 as compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 message(STATUS "CMake version ${CMAKE_VERSION}")
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...4.0)
 project(galera-4)
 
 include(CheckCCompilerFlag)


### PR DESCRIPTION
cmake 4.0 disabled policies defined by cmake < 3.5. So if the project declare the minimum cmake dependency as 2.8, cmake 4.0 will raise an error.

Setting to `2.8...4.0` means  the minimum cmake dependency is 2.8, but also works if cmake 4.0 is used. Or, in another words, the projects build correctly within any versions of cmake between 2.8 and 4.0.