### PR TITLE
MDEV-36926 Support building against Asio 1.14.1 through 1.38.0

### DIFF
--- a/cmake/asio.cmake
+++ b/cmake/asio.cmake
@@ -2,7 +2,18 @@
 # Copyright (C) 2020 Codership Oy <info@codership.com>
 #
 
+# Add an option for specifying a custom Asio installation path
+set(GALERA_CUSTOM_ASIO_PATH "" CACHE STRING "Path to custom Asio installation")
+
 macro(CHECK_ASIO_VERSION)
+  # Store original CMAKE_REQUIRED_INCLUDES value
+  set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
+
+  # Add custom Asio path to CMAKE_REQUIRED_INCLUDES if specified
+  if(GALERA_CUSTOM_ASIO_PATH)
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${GALERA_CUSTOM_ASIO_PATH})
+  endif()
+
   check_cxx_source_compiles(
     "
 #include <asio.hpp>
@@ -10,7 +21,7 @@ macro(CHECK_ASIO_VERSION)
 #define XSTR(x) STR(x)
 #define STR(x) #x
 #pragma message \"Asio version: \" XSTR(ASIO_VERSION)
-#if ASIO_VERSION < 102201
+#if ASIO_VERSION < 101401
 #error Included asio version is too old
 #endif
 
@@ -21,9 +32,18 @@ int main()
 "
   ASIO_VERSION_OK
   )
+
+  # Restore original CMAKE_REQUIRED_INCLUDES
+  set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
 endmacro()
 
-check_include_file_cxx(asio.hpp HAVE_SYSTEM_ASIO_HPP)
+if(GALERA_CUSTOM_ASIO_PATH)
+  message(STATUS "Using custom Asio path: ${GALERA_CUSTOM_ASIO_PATH}")
+  include_directories(SYSTEM ${GALERA_CUSTOM_ASIO_PATH})
+  set(HAVE_SYSTEM_ASIO_HPP TRUE)
+else()
+  check_include_file_cxx(asio.hpp HAVE_SYSTEM_ASIO_HPP)
+endif()
 
 if (HAVE_SYSTEM_ASIO_HPP)
   CHECK_ASIO_VERSION()

--- a/cmake/asio.cmake
+++ b/cmake/asio.cmake
@@ -37,6 +37,38 @@ int main()
   set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
 endmacro()
 
+# Print the major.minor.patch of the Asio that will actually be used.
+# HEADER_DIR is a directory containing "asio/version.hpp"; when empty the
+# default system include paths are searched instead.
+function(REPORT_ASIO_VERSION HEADER_DIR)
+  if(HEADER_DIR)
+    set(version_hpp "${HEADER_DIR}/asio/version.hpp")
+  else()
+    find_file(GALERA_ASIO_VERSION_HPP asio/version.hpp)
+    set(version_hpp "${GALERA_ASIO_VERSION_HPP}")
+    unset(GALERA_ASIO_VERSION_HPP CACHE)
+  endif()
+
+  if(NOT version_hpp OR NOT EXISTS "${version_hpp}")
+    message(STATUS "Asio version: unable to locate asio/version.hpp")
+    return()
+  endif()
+
+  file(STRINGS "${version_hpp}" version_line
+    REGEX "^#define[ \t]+ASIO_VERSION[ \t]+[0-9]+")
+  string(REGEX MATCH "[0-9]+" version "${version_line}")
+  if(NOT version)
+    message(STATUS "Asio version: unable to parse ASIO_VERSION from ${version_hpp}")
+    return()
+  endif()
+
+  # ASIO_VERSION == major * 100000 + minor * 100 + sub_minor
+  math(EXPR major "${version} / 100000")
+  math(EXPR minor "(${version} / 100) % 1000")
+  math(EXPR sub_minor "${version} % 100")
+  message(STATUS "Using Asio version ${major}.${minor}.${sub_minor} (${version_hpp})")
+endfunction()
+
 if(GALERA_CUSTOM_ASIO_PATH)
   message(STATUS "Using custom Asio path: ${GALERA_CUSTOM_ASIO_PATH}")
   include_directories(SYSTEM ${GALERA_CUSTOM_ASIO_PATH})
@@ -49,6 +81,7 @@ if (HAVE_SYSTEM_ASIO_HPP)
   CHECK_ASIO_VERSION()
   if (ASIO_VERSION_OK)
     add_definitions(-DHAVE_ASIO_HPP)
+    REPORT_ASIO_VERSION("${GALERA_CUSTOM_ASIO_PATH}")
   else()
     unset(HAVE_SYSTEM_ASIO_HPP CACHE)
     unset(ASIO_VERSION_OK CACHE)
@@ -57,6 +90,7 @@ endif()
 
 if(NOT ASIO_VERSION_OK)
   message(STATUS "Using bundled asio")
+  REPORT_ASIO_VERSION("${PROJECT_SOURCE_DIR}/asio")
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/asio)
 endif()
 

--- a/galerautils/src/gu_asio.cpp
+++ b/galerautils/src/gu_asio.cpp
@@ -760,7 +760,11 @@ size_t gu::AsioIoService::run()
 
 void gu::AsioIoService::post(std::function<void()> fun)
 {
+#if ASIO_VERSION < 103300
     impl_->native().post(fun);
+#else
+    asio::post(impl_->native(), fun);
+#endif /* ASIO_VERSION < 103300 */
 }
 
 void gu::AsioIoService::stop()
@@ -770,7 +774,11 @@ void gu::AsioIoService::stop()
 
 void gu::AsioIoService::reset()
 {
+#if ASIO_VERSION < 103300
     impl_->native().reset();
+#else
+    impl_->native().restart();
+#endif /* ASIO_VERSION < 103300 */
 }
 
 gu::AsioIoService::Impl& gu::AsioIoService::impl()
@@ -815,7 +823,7 @@ public:
     typedef asio::steady_timer native_timer_type;
 #endif /* #if (__GNUC__ == 4 && __GNUC_MINOR__ == 4) */
 
-    Impl(asio::io_service& io_service) : timer_(io_service) { }
+    Impl(AsioIoService::Impl::native_type& io_service) : timer_(io_service) { }
     native_timer_type& native() { return timer_; }
     void handle_wait(const std::shared_ptr<AsioSteadyTimerHandler>& handler,
                      const asio::error_code& ec)
@@ -852,15 +860,19 @@ gu::AsioSteadyTimer::~AsioSteadyTimer()
 void gu::AsioSteadyTimer::expires_from_now(
     const AsioClock::duration& duration)
 {
+#if ASIO_VERSION < 103300
     impl_->native().expires_from_now(to_native_duration(duration));
+#else
+    impl_->native().expires_after(to_native_duration(duration));
+#endif /* ASIO_VERSION < 103300 */
 }
 
 void gu::AsioSteadyTimer::async_wait(
     const std::shared_ptr<AsioSteadyTimerHandler>& handler)
 {
-    impl_->native().async_wait(boost::bind(&Impl::handle_wait,
-                                           impl_.get(), handler,
-                                           asio::placeholders::error));
+    impl_->native().async_wait([this, handler](const asio::error_code& ec) {
+        impl_->handle_wait(handler, ec);
+    });
 }
 
 void gu::AsioSteadyTimer::cancel()

--- a/galerautils/src/gu_asio_datagram.cpp
+++ b/galerautils/src/gu_asio_datagram.cpp
@@ -19,14 +19,21 @@
 
 #include <boost/bind.hpp>
 
-static asio::ip::udp::resolver::iterator resolve_udp(
-    asio::io_service& io_service,
+static asio::ip::udp::endpoint resolve_udp(
+    asio::io_context& io_service,
     const gu::URI& uri)
 {
     asio::ip::udp::resolver resolver(io_service);
+    // resolve() throws on failure, so on success the result always has
+    // at least one entry.
+#if ASIO_VERSION < 103300
     asio::ip::udp::resolver::query query(gu::unescape_addr(uri.get_host()),
                                          uri.get_port());
-    return resolver.resolve(query);
+    return resolver.resolve(query)->endpoint();
+#else
+    return resolver.resolve(gu::unescape_addr(uri.get_host()),
+                            uri.get_port()).begin()->endpoint();
+#endif /* ASIO_VERSION < 103300 */
 }
 
 static bool is_multicast(const asio::ip::udp::endpoint& ep)
@@ -95,13 +102,13 @@ gu::AsioUdpSocket::~AsioUdpSocket() noexcept(false)
     close();
 }
 
-asio::ip::udp::resolver::iterator
+asio::ip::udp::endpoint
 gu::AsioUdpSocket::resolve_and_open(const gu::URI& uri)
 {
     try
     {
         auto resolve_result(resolve_udp(io_service_.impl().native(), uri));
-        socket_.open(resolve_result->endpoint().protocol());
+        socket_.open(resolve_result.protocol());
         set_fd_options(socket_);
         return resolve_result;
     }
@@ -141,7 +148,7 @@ void gu::AsioUdpSocket::connect(const gu::URI& uri)
 {
     try
     {
-        asio::ip::udp::resolver::iterator resolve_result;
+        asio::ip::udp::endpoint resolve_result;
         if (not socket_.is_open())
         {
             resolve_result = resolve_and_open(uri);
@@ -164,18 +171,18 @@ void gu::AsioUdpSocket::connect(const gu::URI& uri)
             ::make_address(
                 uri.get_option("socket.if_addr",
                                ::any_addr(
-                                   resolve_result->endpoint().address())));
+                                   resolve_result.address())));
 
-        if (is_multicast(resolve_result->endpoint()))
+        if (is_multicast(resolve_result))
         {
-            join_group(socket_, resolve_result->endpoint(), local_if_);
+            join_group(socket_, resolve_result, local_if_);
             socket_.set_option(
                 asio::ip::multicast::enable_loopback(
                     gu::from_string<bool>(uri.get_option("socket.if_loop", "false"))));
             socket_.set_option(
                 asio::ip::multicast::hops(
                     gu::from_string<int>(uri.get_option("socket.mcast_ttl", "1"))));
-            socket_.bind(*resolve_result);
+            socket_.bind(resolve_result);
         }
         else
         {
@@ -234,12 +241,11 @@ void gu::AsioUdpSocket::async_read(
     const AsioMutableBuffer& buffer,
     const std::shared_ptr<AsioDatagramSocketHandler>& handler)
 {
+    auto self = shared_from_this();
     socket_.async_receive(asio::buffer(buffer.data(), buffer.size()),
-                          boost::bind(&AsioUdpSocket::read_handler,
-                                      shared_from_this(),
-                                      handler,
-                                      asio::placeholders::error,
-                                      asio::placeholders::bytes_transferred));
+    [self, handler](const asio::error_code& ec, size_t bytes_transferred) {
+        self->read_handler(handler, ec, bytes_transferred);
+    });
 }
 
 std::string gu::AsioUdpSocket::local_addr() const

--- a/galerautils/src/gu_asio_datagram.hpp
+++ b/galerautils/src/gu_asio_datagram.hpp
@@ -35,7 +35,7 @@ namespace gu
 
         ~AsioUdpSocket() noexcept(false);
 
-        asio::ip::udp::resolver::iterator resolve_and_open(const gu::URI& uri);
+        asio::ip::udp::endpoint resolve_and_open(const gu::URI& uri);
 
         virtual void open(const gu::URI& uri) GALERA_OVERRIDE;
 

--- a/galerautils/src/gu_asio_io_service_impl.hpp
+++ b/galerautils/src/gu_asio_io_service_impl.hpp
@@ -16,7 +16,11 @@
 
 #include "gu_asio.hpp"
 
+#if ASIO_VERSION < 103300
 #include "asio/io_service.hpp"
+#else
+#include "asio/io_context.hpp"
+#endif /* ASIO_VERSION < 103300 */
 #ifdef GALERA_HAVE_SSL
 #include "asio/ssl.hpp"
 #endif // GALERA_HAVE_SSL
@@ -28,16 +32,22 @@ namespace gu
     //
     class AsioIoService::Impl
     {
-    public:
-        Impl()
-            : io_service_()
+        public:
+#if ASIO_VERSION < 103300
+            using native_type = asio::io_service;
+#else
+            using native_type = asio::io_context;
+#endif /* ASIO_VERSION < 103300 */
+
+            Impl()
+                : io_service_()
 #ifdef GALERA_HAVE_SSL
-            , ssl_context_()
+                , ssl_context_()
 #endif // GALERA_HAVE_SSL
         { }
-        asio::io_service& native() { return io_service_; }
+        native_type& native() { return io_service_; }
     private:
-        asio::io_service io_service_;
+        native_type io_service_;
     public:
 #ifdef GALERA_HAVE_SSL
         std::unique_ptr<asio::ssl::context> ssl_context_;

--- a/galerautils/src/gu_asio_io_service_impl.hpp
+++ b/galerautils/src/gu_asio_io_service_impl.hpp
@@ -16,11 +16,7 @@
 
 #include "gu_asio.hpp"
 
-#if ASIO_VERSION < 103300
-#include "asio/io_service.hpp"
-#else
 #include "asio/io_context.hpp"
-#endif /* ASIO_VERSION < 103300 */
 #ifdef GALERA_HAVE_SSL
 #include "asio/ssl.hpp"
 #endif // GALERA_HAVE_SSL
@@ -33,11 +29,7 @@ namespace gu
     class AsioIoService::Impl
     {
         public:
-#if ASIO_VERSION < 103300
-            using native_type = asio::io_service;
-#else
             using native_type = asio::io_context;
-#endif /* ASIO_VERSION < 103300 */
 
             Impl()
                 : io_service_()

--- a/galerautils/src/gu_asio_ip_address_impl.hpp
+++ b/galerautils/src/gu_asio_ip_address_impl.hpp
@@ -17,6 +17,7 @@
 #include "gu_asio.hpp"
 
 #include "asio/ip/address.hpp"
+#include "asio/version.hpp"
 
 namespace gu
 {
@@ -65,7 +66,11 @@ static inline std::string escape_addr(const asio::ip::address& addr)
 
 static inline asio::ip::address make_address(const std::string& addr)
 {
+#if ASIO_VERSION < 103300
     return asio::ip::address::from_string(gu::unescape_addr(addr));
+#else
+    return asio::ip::make_address(gu::unescape_addr(addr));
+#endif /* ASIO_VERSION < 103300 */
 }
 
 static inline std::string any_addr(const asio::ip::address& addr)

--- a/galerautils/src/gu_asio_socket_util.hpp
+++ b/galerautils/src/gu_asio_socket_util.hpp
@@ -113,18 +113,25 @@ static size_t get_send_buffer_size(Socket& socket)
     }
 }
 
-static inline asio::ip::tcp::resolver::iterator resolve_tcp(
-    asio::io_service& io_service,
+static inline asio::ip::tcp::endpoint resolve_tcp(
+    asio::io_context& io_service,
     const gu::URI& uri)
 {
     asio::ip::tcp::resolver resolver(io_service);
-    // Give query flags explicitly to avoid having AI_ADDRCONFIG in
-    // underlying getaddrinfo() hint flags.
+    // Give resolver flags explicitly to avoid having AI_ADDRCONFIG in
+    // underlying getaddrinfo() hint flags. resolve() throws on failure,
+    // so on success the result always has at least one entry.
+#if ASIO_VERSION < 103300
     asio::ip::tcp::resolver::query
         query(gu::unescape_addr(uri.get_host()),
               uri.get_port(),
               asio::ip::tcp::resolver::query::flags(0));
-    return resolver.resolve(query);
+    return resolver.resolve(query)->endpoint();
+#else
+    return resolver.resolve(gu::unescape_addr(uri.get_host()),
+                            uri.get_port(),
+                            asio::ip::tcp::resolver::flags(0)).begin()->endpoint();
+#endif /* ASIO_VERSION < 103300 */
 }
 
 template <class Socket>

--- a/galerautils/src/gu_asio_stream_react.cpp
+++ b/galerautils/src/gu_asio_stream_react.cpp
@@ -63,7 +63,7 @@ gu::AsioStreamReact::~AsioStreamReact()
 void gu::AsioStreamReact::open(const gu::URI& uri) try
 {
     auto resolve_result(resolve_tcp(io_service_.impl().native(), uri));
-    socket_.open(resolve_result->endpoint().protocol());
+    socket_.open(resolve_result.protocol());
     set_fd_options(socket_);
 }
 catch (const asio::system_error& e)
@@ -124,14 +124,14 @@ void gu::AsioStreamReact::async_connect(
     auto resolve_result(resolve_tcp(io_service_.impl().native(), uri));
     if (not socket_.is_open())
     {
-        socket_.open(resolve_result->endpoint().protocol());
+        socket_.open(resolve_result.protocol());
     }
     connected_ = true;
-    socket_.async_connect(*resolve_result,
-                          boost::bind(&AsioStreamReact::connect_handler,
-                                      shared_from_this(),
-                                      handler,
-                                      asio::placeholders::error));
+    auto self = shared_from_this();
+    socket_.async_connect(resolve_result,
+        [self, handler](const asio::error_code& ec) {
+            self->connect_handler(handler, ec);
+        });
 }
 catch (const asio::system_error& e)
 {
@@ -200,10 +200,10 @@ void gu::AsioStreamReact::connect(const gu::URI& uri) try
     auto resolve_result(resolve_tcp(io_service_.impl().native(), uri));
     if (not socket_.is_open())
     {
-        socket_.open(resolve_result->endpoint().protocol());
+        socket_.open(resolve_result.protocol());
         set_fd_options(socket_);
     }
-    socket_.connect(resolve_result->endpoint());
+    socket_.connect(resolve_result);
     connected_ = true;
     prepare_engine(false);
     auto result(engine_->client_handshake());
@@ -707,32 +707,35 @@ void gu::AsioStreamReact::prepare_engine(bool non_blocking)
     }
 }
 
-template <typename Fn, typename ...FnArgs>
-void gu::AsioStreamReact::start_async_read(Fn fn, FnArgs... fn_args)
+template <typename Fn>
+void gu::AsioStreamReact::start_async_read(
+    Fn fn, const std::shared_ptr<AsioSocketHandler>& handler)
 {
     if (in_progress_ & read_in_progress)
     {
         return;
     }
     set_non_blocking(true);
+    auto self = shared_from_this();
     socket_.async_wait(socket_.wait_read,
-                       boost::bind(fn, shared_from_this(), fn_args...,
-                                   asio::placeholders::error));
-    ;
+                       [self, fn, handler](const asio::error_code& ec)
+                       { (self.get()->*fn)(handler, ec); });
     in_progress_ |= read_in_progress;
 }
 
-template <typename Fn, typename ...FnArgs>
-void gu::AsioStreamReact::start_async_write(Fn fn, FnArgs... fn_args)
+template <typename Fn>
+void gu::AsioStreamReact::start_async_write(
+    Fn fn, const std::shared_ptr<AsioSocketHandler>& handler)
 {
     if (in_progress_ & write_in_progress)
     {
         return;
     }
     set_non_blocking(true);
+    auto self = shared_from_this();
     socket_.async_wait(socket_.wait_write,
-                       boost::bind(fn, shared_from_this(), fn_args...,
-                                   asio::placeholders::error));
+                       [self, fn, handler](const asio::error_code& ec)
+                       { (self.get()->*fn)(handler, ec); });
     in_progress_ |= write_in_progress;
 }
 
@@ -865,7 +868,7 @@ gu::AsioAcceptorReact::AsioAcceptorReact(AsioIoService& io_service,
 void gu::AsioAcceptorReact::open(const gu::URI& uri) try
 {
     auto resolve_result(resolve_tcp(io_service_.impl().native(), uri));
-    acceptor_.open(resolve_result->endpoint().protocol());
+    acceptor_.open(resolve_result.protocol());
     set_fd_options(acceptor_);
 }
 catch (const asio::system_error& e)
@@ -884,12 +887,12 @@ void gu::AsioAcceptorReact::listen(const gu::URI& uri) try
     auto resolve_result(resolve_tcp(io_service_.impl().native(), uri));
     if (not acceptor_.is_open())
     {
-        acceptor_.open(resolve_result->endpoint().protocol());
+        acceptor_.open(resolve_result.protocol());
         set_fd_options(acceptor_);
     }
 
     acceptor_.set_option(asio::ip::tcp::socket::reuse_address(true));
-    acceptor_.bind(*resolve_result);
+    acceptor_.bind(resolve_result);
     acceptor_.listen();
     listening_ = true;
 }

--- a/galerautils/src/gu_asio_stream_react.hpp
+++ b/galerautils/src/gu_asio_stream_react.hpp
@@ -95,12 +95,12 @@ namespace gu
         void prepare_engine(bool non_blocking);
         // Start async read if not in progress. May be called several times
         // without handling read in between.
-        template <typename Fn, typename ...FnArgs>
-        void start_async_read(Fn fn, FnArgs... args);
+        template <typename Fn>
+        void start_async_read(Fn fn, const std::shared_ptr<AsioSocketHandler>&);
         // Start async write if not in progress. May be called several times
         // without handling a write in between.
-        template <typename Fn, typename ...FnArgs>
-        void start_async_write(Fn, FnArgs...);
+        template <typename Fn>
+        void start_async_write(Fn, const std::shared_ptr<AsioSocketHandler>&);
 
         void complete_read_op(const std::shared_ptr<AsioSocketHandler>&,
                               size_t bytes_transferred);

--- a/scripts/test_asio_versions.sh
+++ b/scripts/test_asio_versions.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 MariaDB Plc <info@mariadb.com>
+#
+# Helper for testing that Galera builds against a range of Asio versions.
+#
+# For every supported Asio major.minor release the *latest patch* version is
+# downloaded from GitHub and the project is configured and built against it
+# using the GALERA_CUSTOM_ASIO_PATH CMake option (see cmake/asio.cmake). A
+# pass/fail summary is printed at the end.
+#
+# The default version set is the in-tree bundled Asio copy plus the latest
+# patch of every released Asio major.minor from the bundled version (1.14)
+# onwards. The special version "bundled" builds against the repo's own asio/
+# copy (the fallback configuration used when no suitable system Asio is
+# present).
+#
+# Usage:
+#   scripts/test_asio_versions.sh [OPTIONS] [VERSION ...]
+#
+# Options:
+#   -j, --jobs N      parallel build jobs (default: number of CPUs)
+#   -t, --tests       also run the unit tests (ctest) after each build
+#   -w, --workdir D   working directory for downloads and builds
+#                     (default: <repo>/build_asio)
+#   -k, --keep        keep build directories on success (default: removed)
+#   -x, --stop        stop at the first failing version
+#   -h, --help        show this help and exit
+#
+# Positional VERSION arguments (e.g. bundled 1.30.2 1.34.0) override the
+# default set.
+
+set -eu
+
+# "bundled" builds against the repo's in-tree asio/ copy (currently 1.14.1);
+# the rest are the latest patch release for every released Asio major.minor,
+# starting at 1.16 (1.14.1 is covered by "bundled"). 1.15.x, 1.25.x and
+# 1.37.x were never released, hence the gaps.
+# Update this list as new Asio releases appear.
+DEFAULT_VERSIONS=(
+    bundled
+    1.16.1
+    1.17.0
+    1.18.2
+    1.19.2
+    1.20.0
+    1.21.0
+    1.22.2
+    1.23.0
+    1.24.0
+    1.26.0
+    1.27.0
+    1.28.2
+    1.29.0
+    1.30.2
+    1.31.0
+    1.32.0
+    1.33.0
+    1.34.2
+    1.35.0
+    1.36.0
+    1.38.0
+)
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+SRC_DIR=$(cd "$SCRIPT_DIR/.." && pwd -P)
+
+get_cores()
+{
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif [ -r /proc/cpuinfo ]; then
+        grep -c ^processor /proc/cpuinfo
+    else
+        echo 1
+    fi
+}
+
+usage()
+{
+    # Print the leading comment block (skipping the shebang and copyright),
+    # stripping the leading "# ".
+    awk 'NR<=4 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' \
+        "${BASH_SOURCE[0]}"
+}
+
+JOBS=$(get_cores)
+RUN_TESTS="no"
+WORKDIR="$SRC_DIR/build_asio"
+KEEP="no"
+STOP_ON_FAIL="no"
+VERSIONS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -j|--jobs)    JOBS="$2"; shift 2 ;;
+        -t|--tests)   RUN_TESTS="yes"; shift ;;
+        -w|--workdir) WORKDIR="$2"; shift 2 ;;
+        -k|--keep)    KEEP="yes"; shift ;;
+        -x|--stop)    STOP_ON_FAIL="yes"; shift ;;
+        -h|--help)    usage; exit 0 ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)            VERSIONS+=("$1"); shift ;;
+    esac
+done
+
+if [ ${#VERSIONS[@]} -eq 0 ]; then
+    VERSIONS=("${DEFAULT_VERSIONS[@]}")
+fi
+
+# Pick a download command.
+if command -v curl >/dev/null 2>&1; then
+    download() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+    download() { wget -q "$1" -O "$2"; }
+else
+    echo "Error: neither curl nor wget found" >&2
+    exit 1
+fi
+
+mkdir -p "$WORKDIR"
+
+# Download and extract a given Asio version, echo the include directory to use
+# as GALERA_CUSTOM_ASIO_PATH. Cached: re-extracted only if missing.
+fetch_asio()
+{
+    local ver="$1"
+    local tag="asio-${ver//./-}"
+    local tarball="$WORKDIR/${tag}.tar.gz"
+    local extract_dir="$WORKDIR/$tag"
+    local inc_dir="$extract_dir/asio-${tag}/asio/include"
+
+    if [ ! -d "$inc_dir" ]; then
+        if [ ! -s "$tarball" ]; then
+            download \
+                "https://github.com/chriskohlhoff/asio/archive/refs/tags/${tag}.tar.gz" \
+                "$tarball"
+        fi
+        mkdir -p "$extract_dir"
+        tar xzf "$tarball" -C "$extract_dir"
+    fi
+
+    if [ ! -f "$inc_dir/asio.hpp" ]; then
+        echo "Error: asio.hpp not found under $inc_dir" >&2
+        return 1
+    fi
+    echo "$inc_dir"
+}
+
+# Configure and build the project against a single Asio version.
+build_one()
+{
+    local ver="$1"
+    local inc_dir build_dir log
+
+    if [ "$ver" = "bundled" ]; then
+        # Build against the in-tree Asio copy shipped in the repo, i.e. the
+        # fallback configuration used when no suitable system Asio is found.
+        inc_dir="$SRC_DIR/asio"
+    else
+        inc_dir=$(fetch_asio "$ver") || return 1
+    fi
+
+    build_dir="$WORKDIR/build-$ver"
+    log="$WORKDIR/build-$ver.log"
+    rm -rf "$build_dir"
+
+    {
+        echo "=== Asio $ver: configure ==="
+        cmake -S "$SRC_DIR" -B "$build_dir" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DGALERA_CUSTOM_ASIO_PATH="$inc_dir" || return 1
+
+        echo "=== Asio $ver: build ==="
+        cmake --build "$build_dir" -j "$JOBS" || return 1
+
+        if [ "$RUN_TESTS" = "yes" ]; then
+            echo "=== Asio $ver: ctest ==="
+            ctest --test-dir "$build_dir" --output-on-failure || return 1
+        fi
+    } >"$log" 2>&1
+
+    [ "$KEEP" = "yes" ] || rm -rf "$build_dir"
+}
+
+echo "Galera source : $SRC_DIR"
+echo "Work directory: $WORKDIR"
+echo "Parallel jobs : $JOBS"
+echo "Run tests     : $RUN_TESTS"
+echo "Versions      : ${VERSIONS[*]}"
+echo
+
+declare -a RESULTS
+overall_rc=0
+
+for ver in "${VERSIONS[@]}"; do
+    printf '>>> Building against Asio %s ... ' "$ver"
+    if build_one "$ver"; then
+        echo "PASS"
+        RESULTS+=("PASS  $ver")
+    else
+        echo "FAIL (see $WORKDIR/build-$ver.log)"
+        RESULTS+=("FAIL  $ver")
+        overall_rc=1
+        if [ "$STOP_ON_FAIL" = "yes" ]; then
+            break
+        fi
+    fi
+done
+
+echo
+echo "==================== Summary ===================="
+for r in "${RESULTS[@]}"; do
+    echo "  $r"
+done
+echo "================================================="
+
+exit $overall_rc


### PR DESCRIPTION
- **MDEV-36926 Support building against Asio 1.14.1 through 1.38.0**
- **MDEV-36926 Print the selected Asio version at configure time**
- **MDEV-36926 Always use asio::io_context in AsioIoService::Impl**
